### PR TITLE
fix: add static oauth callbacks for static hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.DS_Store
+npm-debug.log*

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,2 @@
+# Replace with your custom domain (optional)
+# example: listbridge.example.com

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# tuningmymusic
+# ListBridge
+
+This repository contains the ListBridge static web application for moving playlists between Spotify and YouTube with OAuth 2.1 PKCE flows. The core documentation lives in [`docs/README.md`](docs/README.md).
+
+## Quick links
+
+- [Setup & usage guide](docs/README.md)
+- [GitHub Pages deployment walkthrough](docs/DEPLOY.md)
+- [Spotify OAuth configuration](docs/OAUTH_SETUP_SPOTIFY.md)
+- [Google OAuth configuration](docs/OAUTH_SETUP_GOOGLE.md)
+- [Extending providers](docs/EXTENDING_PROVIDERS.md)
+
+## Developer scripts
+
+```bash
+npm install     # install optional tooling
+npm run lint    # syntax check JavaScript modules
+npm test        # mapping heuristics unit tests
+npm run build   # generate dist/ for static hosting
+npm run dev     # serve locally via Python http.server
+```
+
+The generated `dist/` directory is safe to upload to GitHub Pages or any static host.

--- a/assets/icons/csv.svg
+++ b/assets/icons/csv.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title id="title">CSV file icon</title>
+  <rect x="8" y="4" width="40" height="56" rx="6" fill="#0f172a" />
+  <path d="M48 20L36 8v8a4 4 0 004 4z" fill="#1db954" />
+  <path d="M20 28h24M20 36h24M20 44h24" stroke="#1db954" stroke-width="3" stroke-linecap="round" />
+  <text x="12" y="56" fill="#1db954" font-family="'Space Grotesk', sans-serif" font-size="10" font-weight="600">CSV</text>
+</svg>

--- a/assets/icons/json.svg
+++ b/assets/icons/json.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title id="title">JSON file icon</title>
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="#111827" />
+  <path d="M18 22c0-3 2.5-5 5.5-5h3.5" stroke="#29d391" stroke-width="4" stroke-linecap="round" />
+  <path d="M18 42c0 3 2.5 5 5.5 5h3.5" stroke="#29d391" stroke-width="4" stroke-linecap="round" />
+  <path d="M46 22c0-3-2.5-5-5.5-5H37" stroke="#29d391" stroke-width="4" stroke-linecap="round" />
+  <path d="M46 42c0 3-2.5 5-5.5 5H37" stroke="#29d391" stroke-width="4" stroke-linecap="round" />
+  <text x="20" y="36" fill="#29d391" font-family="'Space Grotesk', sans-serif" font-size="10" font-weight="600">JSON</text>
+</svg>

--- a/assets/icons/listbridge.svg
+++ b/assets/icons/listbridge.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title">
+  <title id="title">ListBridge mark</title>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1db954" />
+      <stop offset="100%" stop-color="#29d391" />
+    </linearGradient>
+  </defs>
+  <rect x="10" y="30" width="32" height="60" rx="16" fill="url(#grad)" />
+  <rect x="42" y="20" width="32" height="80" rx="16" fill="url(#grad)" opacity="0.8" />
+  <rect x="74" y="40" width="32" height="40" rx="16" fill="url(#grad)" opacity="0.6" />
+  <path d="M20 95h80" stroke="#1db954" stroke-width="6" stroke-linecap="round" />
+  <circle cx="60" cy="95" r="8" fill="#1db954" />
+</svg>

--- a/assets/icons/spotify.svg
+++ b/assets/icons/spotify.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-labelledby="title">
+  <title id="title">Spotify abstract icon</title>
+  <circle cx="32" cy="32" r="30" fill="#121212" />
+  <path
+    d="M18 24c9-2.5 21.5-0.7 29 3.5"
+    stroke="#1db954"
+    stroke-width="4"
+    stroke-linecap="round"
+  />
+  <path
+    d="M20 33c6.5-1.8 15.6-0.5 21 2.5"
+    stroke="#1db954"
+    stroke-width="3.2"
+    stroke-linecap="round"
+    opacity="0.9"
+  />
+  <path
+    d="M22 41.5c4.4-1.2 10.4-0.4 14 1.6"
+    stroke="#1db954"
+    stroke-width="3"
+    stroke-linecap="round"
+    opacity="0.7"
+  />
+</svg>

--- a/assets/icons/youtube.svg
+++ b/assets/icons/youtube.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-labelledby="title">
+  <title id="title">YouTube abstract icon</title>
+  <rect x="4" y="12" width="56" height="40" rx="16" fill="#121212" />
+  <path d="M28 24.5L40.5 32 28 39.5z" fill="#ff0033" />
+  <rect x="10" y="18" width="44" height="28" rx="12" stroke="#ff0033" stroke-width="3" />
+</svg>

--- a/assets/styles/components.css
+++ b/assets/styles/components.css
@@ -1,0 +1,283 @@
+.lb-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.lb-hero h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 0.5rem;
+}
+
+.lb-hero p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: var(--lb-color-muted);
+}
+
+.lb-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.lb-provider-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.lb-card-title {
+  font-weight: 600;
+  font-size: 1.125rem;
+  margin-bottom: 0.25rem;
+}
+
+.lb-provider-card {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.lb-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.lb-card-subtitle {
+  color: var(--lb-color-muted);
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+}
+
+.lb-card-hint {
+  font-size: 0.85rem;
+  color: var(--lb-color-warning);
+}
+
+.lb-status-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0.5rem 0 1rem;
+  color: var(--lb-color-muted);
+}
+
+.lb-status-list li {
+  margin: 0.25rem 0;
+}
+
+.lb-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(29, 185, 84, 0.12);
+  color: var(--lb-color-accent);
+  font-size: 0.85rem;
+}
+
+.lb-progress {
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--lb-color-border);
+  overflow: hidden;
+}
+
+.lb-progress-label {
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.lb-progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--lb-color-accent), #29d391);
+  transition: width 200ms ease;
+  width: 0%;
+}
+
+.lb-log-pane {
+  display: grid;
+  gap: 0.5rem;
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
+  font-size: 0.85rem;
+}
+
+.lb-log-pane ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.lb-log-pane li {
+  padding: 0.25rem 0;
+  border-bottom: 1px dashed var(--lb-color-border);
+}
+
+.lb-table-container {
+  position: relative;
+  height: 420px;
+}
+
+.lb-table-virtual {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: auto;
+}
+
+.lb-table-virtual table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.lb-table-virtual thead tr {
+  position: sticky;
+  top: 0;
+  background: var(--lb-color-surface);
+  z-index: 1;
+}
+
+.lb-table-virtual th,
+.lb-table-virtual td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--lb-color-border);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.lb-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.lb-match-review {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.lb-match-review h3 {
+  margin: 0.2rem 0 0.4rem;
+}
+
+.lb-match-candidates {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.lb-match-candidate {
+  border-radius: var(--lb-radius);
+  border: 1px solid var(--lb-color-border);
+  padding: 0.5rem 0.75rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.lb-match-candidate[aria-selected="true"] {
+  border-color: var(--lb-color-accent);
+  background: rgba(29, 185, 84, 0.12);
+}
+
+.lb-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.lb-alert {
+  padding: 0.75rem 1rem;
+  border-radius: var(--lb-radius);
+  border: 1px solid transparent;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.lb-alert-warning {
+  background: rgba(255, 169, 64, 0.12);
+  border-color: rgba(255, 169, 64, 0.4);
+  color: var(--lb-color-warning);
+}
+
+.lb-alert-danger {
+  background: rgba(255, 77, 79, 0.12);
+  border-color: rgba(255, 77, 79, 0.4);
+  color: var(--lb-color-danger);
+}
+
+.lb-tabs {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.lb-tabs button {
+  background: transparent;
+  color: var(--lb-color-text);
+  border-color: var(--lb-color-border);
+}
+
+.lb-tabs button[aria-selected="true"] {
+  background: rgba(29, 185, 84, 0.12);
+  border-color: var(--lb-color-accent);
+}
+
+.lb-language-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+label.lb-button-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  cursor: pointer;
+}
+
+label.lb-button-secondary input[type="file"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.lb-playlist-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+  display: grid;
+  gap: 0.5rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.lb-playlist-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--lb-color-border);
+  border-radius: var(--lb-radius);
+  background: var(--lb-color-surface);
+}
+
+.lb-playlist-item input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+}

--- a/assets/styles/global.css
+++ b/assets/styles/global.css
@@ -1,0 +1,233 @@
+:root {
+  color-scheme: light dark;
+  --lb-font-stack: "Inter", "Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --lb-radius: 12px;
+  --lb-transition: 150ms ease;
+  --lb-color-bg: #f8f9fb;
+  --lb-color-surface: #ffffff;
+  --lb-color-border: rgba(0, 0, 0, 0.08);
+  --lb-color-text: #1a1a1a;
+  --lb-color-muted: #4a4a4a;
+  --lb-color-accent: #1db954;
+  --lb-color-danger: #ff4d4f;
+  --lb-color-warning: #ffa940;
+  --lb-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"],
+  :root[data-theme="dark"] {
+    --lb-color-bg: #0f1116;
+    --lb-color-surface: #151922;
+    --lb-color-border: rgba(255, 255, 255, 0.08);
+    --lb-color-text: #f3f6ff;
+    --lb-color-muted: #c8cbd9;
+    --lb-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  }
+}
+
+:root[data-theme="light"] {
+  --lb-color-bg: #f8f9fb;
+  --lb-color-surface: #ffffff;
+  --lb-color-border: rgba(0, 0, 0, 0.08);
+  --lb-color-text: #1a1a1a;
+  --lb-color-muted: #4a4a4a;
+  --lb-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--lb-font-stack);
+  background-color: var(--lb-color-bg);
+  color: var(--lb-color-text);
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--lb-color-accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.lb-app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 2rem;
+  background: var(--lb-color-surface);
+  border-bottom: 1px solid var(--lb-color-border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.lb-logo svg {
+  width: 180px;
+  height: auto;
+}
+
+.lb-logo-pill {
+  fill: var(--lb-color-accent);
+}
+
+.lb-logo-text {
+  font-family: "Space Grotesk", var(--lb-font-stack);
+  font-size: 20px;
+  fill: var(--lb-color-text);
+  font-weight: 600;
+}
+
+.lb-nav {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.lb-nav a {
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: background-color var(--lb-transition), color var(--lb-transition), border-color var(--lb-transition);
+}
+
+.lb-nav a:focus,
+.lb-nav a:hover,
+.lb-nav a[aria-current="page"] {
+  background-color: rgba(29, 185, 84, 0.12);
+  border-color: rgba(29, 185, 84, 0.4);
+}
+
+#theme-toggle {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid var(--lb-color-border);
+  background: var(--lb-color-surface);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.lb-app {
+  flex: 1;
+  padding: 1rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.lb-footer {
+  padding: 1rem 2rem;
+  border-top: 1px solid var(--lb-color-border);
+  background: var(--lb-color-surface);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+  font-size: 1rem;
+}
+
+button {
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform var(--lb-transition), box-shadow var(--lb-transition);
+  background: var(--lb-color-accent);
+  color: #fff;
+}
+
+.lb-button-secondary {
+  background: transparent;
+  color: var(--lb-color-text);
+  border-color: var(--lb-color-border);
+}
+
+.lb-button-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  background: var(--lb-color-muted);
+  opacity: 0.6;
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(29, 185, 84, 0.4);
+  outline-offset: 2px;
+}
+
+fieldset {
+  border: 1px solid var(--lb-color-border);
+  border-radius: var(--lb-radius);
+  padding: 1rem 1.5rem;
+  background: var(--lb-color-surface);
+  box-shadow: var(--lb-shadow);
+}
+
+legend {
+  font-weight: 600;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+[data-scrollable] {
+  overflow: auto;
+  border-radius: var(--lb-radius);
+  border: 1px solid var(--lb-color-border);
+  background: var(--lb-color-surface);
+}
+
+[data-card] {
+  padding: 1.25rem;
+  border-radius: var(--lb-radius);
+  border: 1px solid var(--lb-color-border);
+  background: var(--lb-color-surface);
+  box-shadow: var(--lb-shadow);
+}
+
+@media (max-width: 768px) {
+  .lb-app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .lb-nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .lb-app {
+    padding: 1rem 0.75rem;
+  }
+}

--- a/callback/google/index.html
+++ b/callback/google/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Google OAuth Redirect · ListBridge</title>
+    <meta http-equiv="refresh" content="0;url=../index.html#callback/google" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        display: grid;
+        place-items: center;
+        min-height: 100vh;
+        background: #0b0f19;
+        color: #f8fafc;
+        margin: 0;
+      }
+      main {
+        text-align: center;
+        max-width: 32rem;
+        padding: 2rem;
+      }
+    </style>
+    <script>
+      (function redirect() {
+        const query = window.location.search;
+        const hash = query ? `#callback/google?${query.slice(1)}` : "#callback/google";
+        const target = `../index.html${hash}`;
+        if (window.location.replace) {
+          window.location.replace(target);
+        } else {
+          window.location.href = target;
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <main>
+      <h1>Redirecting back to ListBridge…</h1>
+      <p>If the page does not change, <a href="../index.html#callback/google">continue to the app</a>.</p>
+    </main>
+  </body>
+</html>

--- a/callback/spotify/index.html
+++ b/callback/spotify/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Spotify OAuth Redirect · ListBridge</title>
+    <meta http-equiv="refresh" content="0;url=../index.html#callback/spotify" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        display: grid;
+        place-items: center;
+        min-height: 100vh;
+        background: #0b0f19;
+        color: #f8fafc;
+        margin: 0;
+      }
+      main {
+        text-align: center;
+        max-width: 32rem;
+        padding: 2rem;
+      }
+    </style>
+    <script>
+      (function redirect() {
+        const query = window.location.search;
+        const hash = query ? `#callback/spotify?${query.slice(1)}` : "#callback/spotify";
+        const target = `../index.html${hash}`;
+        if (window.location.replace) {
+          window.location.replace(target);
+        } else {
+          window.location.href = target;
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <main>
+      <h1>Redirecting back to ListBridge…</h1>
+      <p>If you are not redirected, <a href="../index.html#callback/spotify">click here</a>.</p>
+    </main>
+  </body>
+</html>

--- a/data/sample-playlists.csv
+++ b/data/sample-playlists.csv
@@ -1,0 +1,2 @@
+playlist_name,description,visibility,source_name
+ListBridge Demo,A short playlist used for demo purposes.,private,spotify

--- a/data/sample-playlists.json
+++ b/data/sample-playlists.json
@@ -1,0 +1,33 @@
+{
+  "source": "spotify",
+  "fetchedAt": "2024-01-01T00:00:00.000Z",
+  "appVersion": "1.0.0",
+  "playlists": [
+    {
+      "id": "demo-1",
+      "name": "ListBridge Demo",
+      "description": "A short playlist used for demo purposes.",
+      "trackCount": 2,
+      "tracks": [
+        {
+          "title": "Synth Waves",
+          "artists": ["Analog Horizon"],
+          "album": "Night Runners",
+          "duration_ms": 215000,
+          "release_year": 2021,
+          "explicit": false,
+          "sourceIds": { "spotify": "3demo1" }
+        },
+        {
+          "title": "City Lights",
+          "artists": ["Dreamstatic", "Feather"],
+          "album": "Skyline",
+          "duration_ms": 198000,
+          "release_year": 2020,
+          "explicit": false,
+          "sourceIds": { "spotify": "3demo2" }
+        }
+      ]
+    }
+  ]
+}

--- a/data/sample-tracks.csv
+++ b/data/sample-tracks.csv
@@ -1,0 +1,3 @@
+playlist_name,position,title,artists,album,duration_ms,isrc,release_year,explicit,cover_url
+ListBridge Demo,1,Synth Waves,Analog Horizon,Night Runners,215000,,2021,false,
+ListBridge Demo,2,City Lights,Dreamstatic; Feather,Skyline,198000,,2020,false,

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,55 @@
+# Deploying ListBridge on GitHub Pages
+
+ListBridge is designed for zero-backend static hosting. These steps publish the app via GitHub Pages.
+
+## Prerequisites
+
+- GitHub account with access to the repository.
+- Spotify & Google OAuth apps configured (see respective guides).
+
+## Steps
+
+1. **Repository setup**
+   - Fork or clone the repo to your GitHub account.
+   - Push the code to the `main` branch.
+
+2. **GitHub Pages configuration**
+   - Open the repository on GitHub → *Settings* → *Pages*.
+   - Set the source to `Deploy from a branch` → `main` → `/ (root)`.
+   - Save. GitHub issues a Pages URL like `https://<username>.github.io/<repo>/`.
+
+3. **SPA routing**
+   - No special 404 handling is required because routes live in the hash (`#/path`).
+   - Optional: add a `CNAME` file at the repo root for custom domains.
+
+4. **Redirect URIs**
+   - Spotify redirect: `https://<username>.github.io/<repo>/callback/spotify`
+   - Google redirect: `https://<username>.github.io/<repo>/callback/google`
+   - The repository provides matching static callback pages that forward tokens back to `index.html`, so no server rewrite rules are required.
+   - These must match exactly (case sensitive) when registering apps.
+
+5. **Client IDs**
+   - Edit `oauth.config.js` in the repository and replace the placeholder Spotify/Google client IDs with your own.
+   - Commit and push the file (or keep a private copy if you prefer not to store IDs in Git). GitHub Pages serves the script before `src/app.js` so the SPA knows which apps to authorize.
+   - After deployment, open the site, navigate to **Connect**, and confirm each provider shows “Configured” before attempting sign-in.
+
+6. **Testing**
+   - Run `npm run lint`, `npm test`, and optionally `npm run build` to ensure quality gates pass locally.
+   - Run through the flows in `test/e2e.md`.
+   - Validate CSP headers by checking the browser console for blocked requests (should be none beyond APIs).
+
+7. **First deployment checklist**
+   1. ✅ Repo pushed to GitHub.
+   2. ✅ GitHub Pages enabled on `main`.
+   3. ✅ CNAME (optional) committed for custom domain.
+   4. ✅ Spotify & Google apps configured with Pages redirect URIs.
+   5. ✅ Spotify/Google client IDs set in `oauth.config.js` and verified on the **Connect** screen.
+   6. ✅ OAuth consent screens published (Google requires production publishing for external use).
+   7. ✅ App loads via HTTPS and passes manual tests.
+
+## Updating
+
+- Commit & push changes to `main`. Pages automatically rebuilds.
+- If CSP changes are needed, edit the `<meta http-equiv="Content-Security-Policy">` tag in `index.html`.
+- Client IDs live in `oauth.config.js`. If they change, edit the file and push/deploy again.
+

--- a/docs/EXTENDING_PROVIDERS.md
+++ b/docs/EXTENDING_PROVIDERS.md
@@ -1,0 +1,53 @@
+# Extending ListBridge Providers
+
+ListBridge ships with Spotify (source) and YouTube (target) providers. Additional services can be integrated by following the contract defined in `src/providers/_template.js`.
+
+## Provider interface
+
+Each provider module must export the following functions:
+
+```js
+export function getCapabilities();
+export async function listPlaylists();
+export async function readTracks(playlistId);
+export async function createPlaylist(options);
+export async function addItems(playlistId, ids);
+export async function search(query);
+```
+
+See `src/providers/provider.types.js` for the shape of playlists and tracks.
+
+## Implementation guidance
+
+1. **Authentication**
+   - Use OAuth 2.1 PKCE whenever possible (see `src/auth/oauth.js`).
+   - For services requiring server-generated tokens (e.g., Apple Music developer tokens), create a small gateway endpoint that issues short-lived tokens. Document the requirement clearly (UI toggles should remain disabled by default).
+
+2. **API wrappers**
+   - Follow the structure in `spotify.js` and `youtube.js`:
+     - `fetchWithRetry` handles 429/5xx retry logic with exponential backoff and jitter.
+     - Respect pagination (limit/pageToken) and rate limits.
+     - Return normalized track objects (`title`, `artists`, `duration_ms`, `sourceIds`).
+
+3. **Mapping heuristics**
+   - Update `src/mapping/rules.js` for stopwords, version tags, and score thresholds relevant to the new provider or locale.
+   - If the provider exposes unique metadata (e.g., ISRC, UPC), enrich `sourceIds` to improve mapping accuracy.
+
+4. **UI integration**
+   - Add new providers to the **Connect** page by importing the module dynamically and rendering a `ProviderConnectCard` instance.
+   - Update `src/workflow/transfer.js` to understand the new target provider (`providerName` should match the key used in `sourceIds`).
+   - Extend i18n entries in `src/ui/i18n.js` for provider-specific text.
+
+5. **Testing**
+   - Add mock implementations in `test/providers.mock.js`.
+   - Extend `test/mapping.test.js` with normalization/scoring cases for new locales.
+   - Update `docs/README.md` and OAuth guides with provider-specific instructions.
+
+## Apple Music note
+
+Apple Music's MusicKit JS requires a developer token signed on a server. For compliance:
+
+- Provide a toggle in the UI that explains the requirement (`Server-signed developer token required`).
+- Implement a provider module that expects a token from the gateway, but keep it disabled until token infrastructure is ready.
+- Never ship the private key or token in the static bundle.
+

--- a/docs/OAUTH_SETUP_GOOGLE.md
+++ b/docs/OAUTH_SETUP_GOOGLE.md
@@ -1,0 +1,49 @@
+# Google / YouTube OAuth Setup (PKCE)
+
+The YouTube Data API v3 supports OAuth 2.0 PKCE. Configure a client for ListBridge as follows.
+
+1. **Create an OAuth consent screen**
+   - Visit <https://console.cloud.google.com/>.
+   - Create or select a project.
+   - Go to *APIs & Services* → *OAuth consent screen*.
+   - Choose *External*, fill in app name/support email, and add your test users (Google requires verification for production use).
+   - Save and submit for verification if needed.
+
+2. **Enable APIs**
+   - In *APIs & Services* → *Library*, enable **YouTube Data API v3**.
+
+3. **Create credentials**
+    - Go to *Credentials* → **Create credentials** → *OAuth client ID*.
+    - Select *Web application*.
+    - Add authorized redirect URIs:
+        - Local dev: `http://localhost:4173/callback/google`
+        - GitHub Pages: `https://<username>.github.io/<repo>/callback/google`
+        - The repo includes `callback/google/index.html`, which immediately bounces the browser back to `index.html#callback/google` so PKCE flows work on a static host.
+    - Click **Create** and copy the *Client ID* (no secret required for PKCE).
+    - Edit `oauth.config.js` and replace the Google `clientId` placeholder with the copied value. Save/commit before deploying so the static site serves the updated config.
+
+4. **Configure scopes**
+   - ListBridge requests `https://www.googleapis.com/auth/youtube` (full playlist access).
+   - If you prefer granular permissions, ensure you include at least:
+     - `https://www.googleapis.com/auth/youtube.readonly`
+     - `https://www.googleapis.com/auth/youtube.force-ssl`
+     - `https://www.googleapis.com/auth/youtube.upload`
+
+5. **Quota planning**
+   - Each `playlists.insert` costs 50 units.
+   - Each `playlistItems.insert` costs 50 units per track addition.
+   - Daily quota is 10,000 units by default (approx. 100 playlist item inserts).
+   - The UI shows estimated remaining units via `QuotaHint`.
+
+6. **Testing checklist**
+    - [ ] OAuth consent screen published (or test users added).
+    - [ ] Google Client ID defined in `oauth.config.js` and showing as “Configured” on **Connect**.
+    - [ ] Authorization prompt shows requested scopes.
+    - [ ] After approval, app navigates back to `#/connect` and shows Google connected.
+    - [ ] Network tab confirms tokens exchanged via `https://oauth2.googleapis.com/token`.
+
+7. **Troubleshooting**
+   - `redirect_uri_mismatch`: verify the URI exactly matches the one in the Google console.
+   - `access_denied`: user canceled consent or scopes require verification.
+   - Quota exhaustion: wait until 00:00 Pacific Time when quotas reset. Use the report export to resume later.
+

--- a/docs/OAUTH_SETUP_SPOTIFY.md
+++ b/docs/OAUTH_SETUP_SPOTIFY.md
@@ -1,0 +1,39 @@
+# Spotify OAuth Setup (PKCE)
+
+ListBridge uses Spotify's PKCE-based Authorization Code flow. Follow these steps to configure an app.
+
+1. **Create an application**
+   - Visit <https://developer.spotify.com/dashboard> and sign in.
+   - Click **Create app** → name it (e.g., `ListBridge`), supply a description, and select the required scopes.
+   - Agree to terms and create the app.
+
+2. **Add redirect URI**
+    - In the app settings, click **Edit settings**.
+    - Under *Redirect URIs*, add the Pages/local URL followed by `callback/spotify`. Examples:
+        - Local dev: `http://localhost:4173/callback/spotify`
+        - GitHub Pages: `https://<username>.github.io/<repo>/callback/spotify`
+    - The repository ships a static `callback/spotify/index.html` helper that immediately forwards the auth response back to `index.html#callback/spotify`, so the redirect works on 100% static hosts.
+    - Save.
+
+3. **Client information**
+   - Copy the **Client ID**. No client secret is required.
+   - Edit `oauth.config.js` and replace the Spotify `clientId` placeholder with the copied value. Save the file (and commit if deploying to GitHub Pages).
+
+4. **Scopes required**
+   - `playlist-read-private`
+   - `user-library-read` (optional, for liked tracks import)
+   - `playlist-modify-private`
+   - `playlist-modify-public`
+
+5. **Testing checklist**
+    - [ ] Redirect URI saved.
+    - [ ] Spotify Client ID defined in `oauth.config.js` and showing as “Configured” on **Connect**.
+    - [ ] Authorization dialog displays ListBridge app name.
+    - [ ] After consent, the app returns to `#/connect` and shows “Connected”.
+    - [ ] `sessionStorage` contains `listbridge.tokens.v1` with Spotify token (inspect via DevTools).
+
+6. **Troubleshooting**
+   - `INVALID_CLIENT`: ensure the Client ID is correct and not the Client Secret.
+   - `INVALID_REDIRECT_URI`: confirm the URI matches exactly (scheme/host/path).
+   - `INSUFFICIENT_CLIENT_SCOPE`: Spotify caches scopes per session; log out from accounts.spotify.com and retry.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,107 @@
+# ListBridge
+
+ListBridge is a security-focused, fully static single-page web application that moves playlists between Spotify and YouTube. It runs entirely in the browser (GitHub Pages friendly) using OAuth 2.1 PKCE and official APIs only. No secrets or tokens ever leave the user's device.
+
+## Features
+
+- ✅ Spotify & Google authentication via OAuth 2.1 PKCE (no client secrets).
+- ✅ Playlist import from Spotify, JSON, or CSV.
+- ✅ Auto mapping of tracks using normalization + similarity scoring.
+- ✅ Manual review UI for ambiguous matches.
+- ✅ Batched playlist creation on YouTube with quota awareness.
+- ✅ Export to CSV/JSON and failure logs for auditing.
+- ✅ Resume support using encrypted storage (optional).
+- ✅ Responsive, accessible UI with dark mode, keyboard navigation, and i18n (ko/en).
+- ✅ 100% static deployable bundle (HTML/CSS/JS) – no build step required.
+- ✅ OAuth client IDs loaded from `oauth.config.js` so sign-in buttons immediately launch the official pop-ups.
+
+## Quick start
+
+1. Clone this repository and serve it locally:
+   ```bash
+   npm install # optional, for scripts
+   npm run dev
+   # or: python3 -m http.server 4173
+   ```
+   - Optional quality checks before committing:
+     ```bash
+     npm run lint
+     npm test
+     npm run build
+     ```
+2. Follow the OAuth setup guides in `docs/OAUTH_SETUP_SPOTIFY.md` and `docs/OAUTH_SETUP_GOOGLE.md` to create client IDs and register redirect URIs.
+3. Edit `oauth.config.js` in the project root and replace the placeholder Spotify/Google client IDs with your own (no secrets required).
+4. Open the app (default `http://localhost:4173`), navigate to **Connect**, confirm both providers show “Configured”, and use the **Connect** cards to authorize. The login pop-ups use the IDs defined in `oauth.config.js`.
+5. Import playlists (Spotify/JSON/CSV) on **Select** and preview tracks.
+6. Run **Match** to auto-map tracks, then manually review any remaining items.
+7. Start **Transfer** to create playlists on YouTube, monitor quota and progress, and download the final report.
+
+## Folder structure
+
+```
+index.html              # SPA entry point
+assets/                 # Icons and stylesheets
+src/                    # ES modules for app logic
+  auth/                 # OAuth flows (PKCE)
+  providers/            # Provider implementations (Spotify, YouTube)
+  mapping/              # Normalization + scoring engine
+  workflow/             # Import/export/transfer pipelines
+  ui/                   # Components, router, i18n
+  config.js             # Runtime configuration storage
+  state.js              # Global state & persistence helpers
+  util.js               # Shared utilities
+  app.js                # Bootstrap + route handlers
+docs/                   # Guides & deployment docs
+test/                   # Browser/Node friendly test assets
+data/                   # Sample CSV/JSON files for demo
+callback/               # Static OAuth redirect helpers (Spotify/Google)
+```
+
+## Static deployment
+
+- Copy the repository contents to any static host (GitHub Pages recommended).
+- Ensure the redirect URIs configured in Spotify and Google match the final Pages URL plus `callback/spotify` and `callback/google` (the included static callback pages forward tokens into the hash router).
+- See `docs/DEPLOY.md` for a step-by-step GitHub Pages guide.
+
+## Security & privacy
+
+- PKCE + implicit flow ensures no secrets in the bundle.
+- Access/refresh tokens are stored in `sessionStorage` by default; optional encrypted `localStorage` persistence is available.
+- No network requests other than Spotify/YouTube APIs.
+- Content Security Policy is embedded in `index.html` to restrict origins.
+- Logs and reports stay local (downloadable CSV/JSON only).
+
+## Accessibility & UX
+
+- Semantic HTML, ARIA roles, and live regions for screen readers.
+  - `util.js#announce()` broadcasts status updates.
+- Keyboard-friendly navigation and focus states.
+- Responsive layout supporting mobile/tablet/desktop.
+- Dark/light/system theme toggle with persisted preference.
+- Multi-language support via `src/ui/i18n.js`.
+
+## Testing & quality
+
+- `npm run lint` performs Node syntax validation across JavaScript sources.
+- `npm test` runs `test/mapping.test.js` (Node, ES modules).
+- `npm run build` creates a distributable `dist/` folder that you can deploy as-is.
+- Manual E2E: `test/e2e.md` enumerates end-to-end scenarios.
+- Lighthouse guidance: aim for 90+ Performance/Accessibility/Best Practices/SEO.
+
+## Extending
+
+- Provider template (`src/providers/_template.js`) documents the minimal interface to integrate new services (e.g., Apple Music via server-signed tokens).
+- Mapping rules (`src/mapping/rules.js`) include stopwords, version tags, and scoring thresholds that can be extended per locale.
+- Client IDs live in `oauth.config.js`, while tokens/preferences stay in the browser (session or encrypted local storage).
+
+## Known limitations
+
+- YouTube quotas apply (playlist & playlistItems insert cost 50 units each); heavy transfers may require multiple days.
+- YouTube Music mirrors YouTube playlists with slight propagation delay; expect up to several minutes before new playlists appear.
+- Apple Music requires a server-signed developer token; the template hook is provided, but default build keeps it disabled.
+- Browser execution means large playlists (5k tracks) rely on virtualization; ensure modern browsers for optimal performance.
+- PWA manifest included but offline functionality limited to shell (API calls require connectivity).
+
+## License
+
+MIT License. Contributions and forks welcome.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ko" data-theme="system">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; img-src 'self' data: https://i.scdn.co https://i.ytimg.com; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://accounts.spotify.com https://api.spotify.com https://accounts.google.com https://oauth2.googleapis.com https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="ListBridge – Spotify에서 YouTube로 플레이리스트를 안전하게 옮기는 100% 정적 웹앱" />
+    <title>ListBridge</title>
+    <link rel="stylesheet" href="./assets/styles/global.css" />
+    <link rel="stylesheet" href="./assets/styles/components.css" />
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="icon" type="image/svg+xml" href="./assets/icons/listbridge.svg" />
+  </head>
+  <body>
+    <noscript>
+      <p>
+        ListBridge는 JavaScript 기반으로 동작합니다. 브라우저에서 JavaScript를 활성화한 뒤
+        다시 방문해 주세요.
+      </p>
+    </noscript>
+    <header class="lb-app-header" role="banner">
+      <div class="lb-logo" aria-label="ListBridge logo" tabindex="0">
+        <svg viewBox="0 0 120 32" aria-hidden="true" focusable="false">
+          <rect x="0" y="8" width="28" height="16" rx="8" class="lb-logo-pill"></rect>
+          <rect x="12" y="4" width="16" height="24" rx="8" class="lb-logo-pill"></rect>
+          <text x="44" y="21" class="lb-logo-text">ListBridge</text>
+        </svg>
+      </div>
+      <nav class="lb-nav" aria-label="Primary">
+        <a href="#/" data-route>Welcome</a>
+        <a href="#/connect" data-route>Connect</a>
+        <a href="#/select" data-route>Select</a>
+        <a href="#/map" data-route>Match</a>
+        <a href="#/transfer" data-route>Transfer</a>
+        <a href="#/report" data-route>Report</a>
+      </nav>
+      <button id="theme-toggle" aria-label="Toggle color scheme"></button>
+    </header>
+    <main id="app" class="lb-app" role="main" tabindex="-1"></main>
+    <footer class="lb-footer" role="contentinfo">
+      <small>
+        © <span data-bind="year"></span> ListBridge. Spotify 또는 Google과 제휴하지 않았습니다.
+      </small>
+      <a href="./docs/README.md" target="_blank" rel="noopener">문서 보기</a>
+    </footer>
+    <template id="sr-live-region">
+      <div class="sr-only" aria-live="polite" aria-atomic="true"></div>
+    </template>
+    <script src="./oauth.config.js"></script>
+    <script type="module" src="./src/app.js"></script>
+  </body>
+</html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "ListBridge",
+  "short_name": "ListBridge",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#121212",
+  "theme_color": "#1db954",
+  "description": "Transfer playlists between Spotify and YouTube safely in the browser.",
+  "icons": [
+    {
+      "src": "./assets/icons/listbridge.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/oauth.config.js
+++ b/oauth.config.js
@@ -1,0 +1,23 @@
+/**
+ * Runtime OAuth configuration for ListBridge.
+ *
+ * Replace the placeholder client IDs with the values from your Spotify and Google OAuth apps.
+ * The file is loaded before the SPA bootstraps so the login buttons can launch immediately
+ * without entering IDs through the UI. Do not include client secrets.
+ */
+window.OAUTH_CONFIG = Object.freeze({
+  spotify: {
+    /**
+     * Spotify application Client ID.
+     * @see https://developer.spotify.com/dashboard
+     */
+    clientId: "",
+  },
+  google: {
+    /**
+     * Google OAuth Client ID for YouTube Data API v3.
+     * @see https://console.cloud.google.com/apis/credentials
+     */
+    clientId: "",
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "listbridge",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "listbridge",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "listbridge",
+  "version": "1.0.0",
+  "description": "ListBridge – static playlist transfer webapp for Spotify and YouTube",
+  "type": "module",
+  "scripts": {
+    "dev": "python3 -m http.server 4173",
+    "lint": "node ./scripts/lint.mjs",
+    "test": "node test/mapping.test.js",
+    "build": "node ./scripts/build.mjs",
+    "check": "npm run lint && npm test"
+  },
+  "keywords": ["spotify", "youtube", "playlist", "transfer", "static", "pkce"],
+  "author": "ListBridge Contributors",
+  "license": "MIT"
+}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cwd = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(cwd, '..');
+const distDir = join(projectRoot, 'dist');
+
+const entries = [
+  'index.html',
+  'manifest.webmanifest',
+  'oauth.config.js',
+  'CNAME',
+];
+
+const directories = ['assets', 'src', 'docs', 'data', 'callback'];
+
+await fs.rm(distDir, { recursive: true, force: true });
+await fs.mkdir(distDir, { recursive: true });
+
+for (const entry of entries) {
+  await copyIfExists(join(projectRoot, entry), join(distDir, entry));
+}
+
+for (const directory of directories) {
+  await copyIfExists(join(projectRoot, directory), join(distDir, directory));
+}
+
+console.log('[build] Static bundle generated in dist/. Upload its contents to any static host.');
+
+async function copyIfExists(src, dest) {
+  try {
+    const stat = await fs.stat(src);
+    if (stat.isDirectory()) {
+      await copyDirectory(src, dest);
+    } else if (stat.isFile()) {
+      await fs.mkdir(dirname(dest), { recursive: true });
+      await fs.copyFile(src, dest);
+      console.log(`→ ${relative(dest)}`);
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+}
+
+async function copyDirectory(src, dest) {
+  await fs.mkdir(dest, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === '.DS_Store') continue;
+    await copyIfExists(join(src, entry.name), join(dest, entry.name));
+  }
+}
+
+function relative(path) {
+  return path.replace(projectRoot + '/', '');
+}

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import { join, extname, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+
+const execFileAsync = promisify(execFile);
+
+const cwd = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(cwd, '..');
+
+const fixRequested = process.argv.includes('--fix');
+if (fixRequested) {
+  console.log('[lint] --fix requested: syntax checks run but no automatic fixes are applied.');
+}
+
+const targets = [
+  'src',
+  'test',
+  'scripts',
+  'oauth.config.js',
+];
+
+const files = [];
+
+for (const target of targets) {
+  await collect(join(projectRoot, target));
+}
+
+if (files.length === 0) {
+  console.log('[lint] No JavaScript files discovered.');
+  process.exit(0);
+}
+
+let failures = 0;
+for (const file of files) {
+  try {
+    await execFileAsync('node', ['--check', file]);
+    console.log(`✓ ${file.replace(projectRoot + '/', '')}`);
+  } catch (error) {
+    failures += 1;
+    console.error(`✗ ${file.replace(projectRoot + '/', '')}`);
+    if (error.stderr) {
+      console.error(error.stderr.trim());
+    } else {
+      console.error(error);
+    }
+  }
+}
+
+if (failures > 0) {
+  console.error(`[lint] ${failures} file(s) failed syntax checks.`);
+  process.exit(1);
+}
+
+console.log('[lint] All files passed Node syntax validation.');
+
+async function collect(entry) {
+  try {
+    const stat = await fs.stat(entry);
+    if (stat.isDirectory()) {
+      const base = entry.replace(projectRoot + '/', '');
+      if (['node_modules', 'dist', '.git'].some((skip) => base.split('/').includes(skip))) {
+        return;
+      }
+      const dirents = await fs.readdir(entry, { withFileTypes: true });
+      for (const dirent of dirents) {
+        await collect(join(entry, dirent.name));
+      }
+    } else if (stat.isFile()) {
+      if (['.js', '.mjs', '.cjs'].includes(extname(entry))) {
+        files.push(entry);
+      }
+    }
+  } catch (error) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,599 @@
+import { initState, subscribe, getState, updateState, setPersistence, unlockEncryptedState } from "./state.js";
+import { initRouter, registerRoute, rerender } from "./ui/router.js";
+import { ProviderConnectCard } from "./ui/components/providerConnectCard.js";
+import { PlaylistPicker } from "./ui/components/playlistPicker.js";
+import { TrackTable } from "./ui/components/trackTable.js";
+import { MatchReview } from "./ui/components/matchReview.js";
+import { ProgressBar } from "./ui/components/progressBar.js";
+import { LogPane } from "./ui/components/logPane.js";
+import { QuotaHint } from "./ui/components/quotaHint.js";
+import { authorizeSpotify, handleSpotifyRedirect, disconnectSpotify } from "./auth/spotifyAuth.js";
+import { authorizeGoogle, handleGoogleRedirect, disconnectGoogle } from "./auth/googleAuth.js";
+import * as spotifyProvider from "./providers/spotify.js";
+import * as youtubeProvider from "./providers/youtube.js";
+import { exportAsCSV, exportAsJSON } from "./workflow/export.js";
+import { importFromJSON, importFromCSV } from "./workflow/import.js";
+import { transferCollection } from "./workflow/transfer.js";
+import { getCheckpoint, clearCheckpoint } from "./workflow/resume.js";
+import { getConfig } from "./config.js";
+import { translate } from "./ui/i18n.js";
+import { findCandidates } from "./mapping/searcher.js";
+import { toCSV, downloadFile, announce } from "./util.js";
+
+const appNode = document.getElementById("app");
+const themeToggle = document.getElementById("theme-toggle");
+const yearNode = document.querySelector('[data-bind="year"]');
+if (yearNode) yearNode.textContent = String(new Date().getFullYear());
+
+initState().then(async () => {
+  await detectCallback();
+  registerRoutes();
+  initRouter(appNode);
+  setupThemeToggle();
+  renderNavState();
+  subscribe(() => {
+    renderNavState();
+    rerender();
+  });
+});
+
+async function detectCallback() {
+  const hash = window.location.hash;
+  if (hash.startsWith("#callback/spotify")) {
+    const search = hash.split("?")[1] ?? "";
+    const url = `${window.location.origin}${window.location.pathname}?${search}`;
+    await handleSpotifyRedirect(url);
+    window.location.hash = "#/connect";
+  }
+  if (hash.startsWith("#callback/google")) {
+    const search = hash.split("?")[1] ?? "";
+    const url = `${window.location.origin}${window.location.pathname}?${search}`;
+    await handleGoogleRedirect(url);
+    window.location.hash = "#/connect";
+  }
+}
+
+function registerRoutes() {
+  registerRoute("/", () => {
+    const state = getState();
+    const container = document.createElement("section");
+    container.className = "lb-hero";
+    const text = document.createElement("div");
+    text.innerHTML = `
+      <h1>${translate("welcome_title", state.locale)}</h1>
+      <p>${translate("welcome_subtitle", state.locale)}</p>
+      <p class="lb-language-switcher">
+        Language:
+        <select id="locale-switcher">
+          <option value="en">English</option>
+          <option value="ko">한국어</option>
+        </select>
+      </p>
+    `;
+    const banner = maybeResumeBanner();
+    const illustration = document.createElement("div");
+    illustration.innerHTML = `
+      <img src="./assets/icons/listbridge.svg" alt="ListBridge logo" style="max-width: 280px;" />
+    `;
+    container.append(text, illustration);
+    if (banner) container.appendChild(banner);
+
+    setTimeout(() => {
+      const switcher = document.getElementById("locale-switcher");
+      if (switcher) {
+        switcher.value = state.locale;
+        switcher.addEventListener("change", (event) => {
+          updateState({ locale: event.target.value });
+        });
+      }
+    }, 0);
+    return container;
+  });
+
+  registerRoute("/connect", () => {
+    const state = getState();
+    const config = getConfig();
+    const container = document.createElement("div");
+    container.className = "lb-grid";
+
+    const introCard = document.createElement("div");
+    introCard.setAttribute("data-card", "");
+
+    const introTitle = document.createElement("h2");
+    introTitle.textContent = translate("connect_title", state.locale);
+
+    const introBody = document.createElement("p");
+    introBody.textContent =
+      "ListBridge opens the official Spotify and Google authorization dialogs. Update oauth.config.js with your client IDs so the pop-ups can launch immediately.";
+
+    const statusList = document.createElement("ul");
+    statusList.className = "lb-status-list";
+    statusList.appendChild(createStatusItem("Spotify Client ID", config.spotify.clientId));
+    statusList.appendChild(createStatusItem("Google Client ID", config.google.clientId));
+
+    const redirectLabel = document.createElement("p");
+    redirectLabel.className = "hint";
+    redirectLabel.textContent = "Redirect URIs to register:";
+
+    const redirectContainer = document.createElement("div");
+    const spotifyRedirect = document.createElement("code");
+    spotifyRedirect.textContent = config.spotify.redirectUri;
+    const googleRedirect = document.createElement("code");
+    googleRedirect.textContent = config.google.redirectUri;
+    redirectContainer.append(spotifyRedirect, document.createElement("br"), googleRedirect);
+
+    const docsHint = document.createElement("p");
+    docsHint.className = "lb-card-hint";
+    docsHint.innerHTML =
+      'Guides: <a href="./docs/OAUTH_SETUP_SPOTIFY.md" target="_blank" rel="noopener">Spotify OAuth</a> · <a href="./docs/OAUTH_SETUP_GOOGLE.md" target="_blank" rel="noopener">Google OAuth</a>';
+
+    introCard.append(introTitle, introBody, statusList, redirectLabel, redirectContainer, docsHint);
+
+    const configCard = document.createElement("div");
+    configCard.setAttribute("data-card", "");
+    configCard.innerHTML = `
+      <h2>Configure OAuth client IDs</h2>
+      <p>Edit <code>oauth.config.js</code> in the project root and set your Spotify and Google client IDs before deploying. The file loads before the app so the sign-in buttons know which application to launch.</p>
+      <pre><code>window.OAUTH_CONFIG = {
+  spotify: { clientId: "YOUR_SPOTIFY_CLIENT_ID" },
+  google: { clientId: "YOUR_GOOGLE_CLIENT_ID" }
+};</code></pre>
+      <p class="lb-card-hint">Client IDs are public identifiers—never add client secrets.</p>
+    `;
+
+    const spotifyCard = ProviderConnectCard({
+      provider: "spotify",
+      locale: state.locale,
+      icon: "./assets/icons/spotify.svg",
+      token: state.tokens.spotify,
+      canConnect: Boolean(config.spotify.clientId),
+      disabledMessage: translate("connect_client_id_hint", state.locale),
+      onConnect: () => authorizeSpotify().catch(showError),
+      onDisconnect: () => disconnectSpotify(),
+    });
+    const googleCard = ProviderConnectCard({
+      provider: "google",
+      locale: state.locale,
+      icon: "./assets/icons/youtube.svg",
+      token: state.tokens.google,
+      canConnect: Boolean(config.google.clientId),
+      disabledMessage: translate("connect_client_id_hint", state.locale),
+      onConnect: () => authorizeGoogle().catch(showError),
+      onDisconnect: () => disconnectGoogle(),
+    });
+
+    const persistenceForm = document.createElement("form");
+    persistenceForm.setAttribute("data-card", "");
+    persistenceForm.innerHTML = `
+      <h2>Token storage</h2>
+      <p>Tokens are stored in sessionStorage by default. Provide a passphrase to enable encrypted localStorage persistence on this device.</p>
+      <label>Passphrase <input type="password" name="passphrase" autocomplete="new-password" /></label>
+      <div class="lb-button-row">
+        <button type="button" id="enable-encrypted">Enable encrypted storage</button>
+        <button type="button" id="disable-encrypted" class="lb-button-secondary">Use session only</button>
+      </div>
+    `;
+
+    setTimeout(() => attachPersistenceListeners(persistenceForm), 0);
+
+    container.append(introCard, configCard, spotifyCard, googleCard, persistenceForm);
+    return container;
+
+    function createStatusItem(label, clientId) {
+      const item = document.createElement("li");
+      if (!clientId) {
+        item.textContent = `${label}: Not configured (edit oauth.config.js)`;
+      } else {
+        const trimmed = String(clientId).trim();
+        const masked = trimmed.length > 8 ? `…${trimmed.slice(-6)}` : trimmed;
+        item.textContent = `${label}: Configured (${masked})`;
+      }
+      return item;
+    }
+
+  });
+
+  registerRoute("/select", () => {
+    const state = getState();
+    const container = document.createElement("div");
+    container.className = "lb-grid";
+
+    const sourceActions = document.createElement("div");
+    sourceActions.setAttribute("data-card", "");
+    sourceActions.innerHTML = `
+      <h2>Select source</h2>
+      <div class="lb-button-row">
+        <button type="button" id="load-spotify">Load Spotify playlists</button>
+        <label class="lb-button-secondary" id="import-json">${translate("import_json", state.locale)}<input type="file" accept="application/json" hidden /></label>
+        <label class="lb-button-secondary" id="import-csv">${translate("import_csv", state.locale)}<input type="file" accept=".csv" hidden multiple /></label>
+      </div>
+    `;
+    container.appendChild(sourceActions);
+
+    if (state.playlists.length) {
+      const picker = PlaylistPicker({
+        playlists: state.playlists,
+        selectedIds: new Set(state.selectedPlaylists),
+        onChange: (selected) => updateState({ selectedPlaylists: [...selected] }),
+      });
+      container.appendChild(picker);
+
+      const previewPlaylist = state.playlists.find((playlist) => state.selectedPlaylists.includes(playlist.id));
+      if (previewPlaylist) {
+        if (!previewPlaylist.tracks && state.source === "spotify") {
+          spotifyProvider
+            .readTracks(previewPlaylist.id)
+            .then((tracks) => {
+              const updated = getState().playlists.map((p) => (p.id === previewPlaylist.id ? { ...p, tracks } : p));
+              updateState({ playlists: updated });
+              rerender();
+            })
+            .catch(showError);
+        }
+        const table = TrackTable({ tracks: previewPlaylist.tracks ?? [] });
+        container.appendChild(table);
+      }
+    }
+
+    const exportActions = document.createElement("div");
+    exportActions.setAttribute("data-card", "");
+    exportActions.innerHTML = `
+      <h2>Export</h2>
+      <div class="lb-button-row">
+        <button type="button" id="export-json">${translate("export_json", state.locale)}</button>
+        <button type="button" id="export-csv">${translate("export_csv", state.locale)}</button>
+      </div>
+    `;
+    container.appendChild(exportActions);
+
+    setTimeout(() => attachSelectListeners(sourceActions, exportActions), 0);
+    return container;
+  });
+
+  registerRoute("/map", () => {
+    const state = getState();
+    const container = document.createElement("div");
+    container.className = "lb-grid";
+
+    const actions = document.createElement("div");
+    actions.setAttribute("data-card", "");
+    actions.innerHTML = `<h2>${translate("map_title", state.locale)}</h2><button type="button" id="auto-map">Run auto matching</button>`;
+    container.appendChild(actions);
+
+    const pending = state.mapping.pending;
+    if (pending.length) {
+      const review = MatchReview({
+        track: pending[0].track,
+        candidates: pending[0].candidates,
+        onSelect: (candidate) => {
+          const key = getTrackKey(pending[0].track);
+          const current = getState().mapping;
+          const matches = { ...current.matches, [key]: candidate };
+          const rest = pending.slice(1);
+          const logs = [
+            ...current.logs,
+            { level: "info", message: `Manual match selected for ${pending[0].track.title}`, timestamp: Date.now() },
+          ];
+          updateState({ mapping: { ...current, matches, pending: rest, logs } });
+          rerender();
+        },
+      });
+      container.appendChild(review);
+    } else {
+      const info = document.createElement("p");
+      info.textContent = "All tracks matched. You can proceed to transfer.";
+      container.appendChild(info);
+    }
+
+    setTimeout(() => {
+      const button = document.getElementById("auto-map");
+      if (button) button.addEventListener("click", () => runAutoMapping().catch(showError));
+    }, 0);
+    return container;
+  });
+
+  registerRoute("/transfer", () => {
+    const state = getState();
+    const container = document.createElement("div");
+    container.className = "lb-grid";
+    const progress = ProgressBar({ label: translate("transfer_title", state.locale) });
+    progress.setProgress(state.transfer.processed, state.transfer.total);
+    container.appendChild(progress.element);
+
+    if (state.mapping.pending.length) {
+      const warning = document.createElement("div");
+      warning.className = "lb-alert lb-alert-warning";
+      warning.textContent = `${state.mapping.pending.length} tracks still require manual review.`;
+      container.appendChild(warning);
+    }
+
+    const startBtn = document.createElement("button");
+    startBtn.type = "button";
+    startBtn.textContent = "Start transfer";
+    startBtn.addEventListener("click", () => {
+      startBtn.disabled = true;
+      startTransfer(progress).finally(() => {
+        startBtn.disabled = false;
+      });
+    });
+    container.appendChild(startBtn);
+
+    const quota = QuotaHint({ usage: youtubeProvider.getQuotaUsage() });
+    container.appendChild(quota);
+    return container;
+  });
+
+  registerRoute("/report", () => {
+    const state = getState();
+    const container = document.createElement("div");
+    container.className = "lb-grid";
+    container.appendChild(LogPane({ entries: state.mapping.logs }));
+    const summary = document.createElement("div");
+    summary.setAttribute("data-card", "");
+    summary.innerHTML = `
+      <h2>${translate("report_title", state.locale)}</h2>
+      <p>Total processed: ${state.transfer.processed}</p>
+      <p>Failures: ${state.transfer.failures.length}</p>
+    `;
+    if (state.transfer.failures.length) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = "Export failures CSV";
+      button.addEventListener("click", () => exportFailures(state.transfer.failures));
+      summary.appendChild(button);
+    }
+    container.appendChild(summary);
+    return container;
+  });
+}
+
+function attachSelectListeners(sourceActions, exportActions) {
+  const loadSpotifyBtn = sourceActions.querySelector("#load-spotify");
+  if (loadSpotifyBtn) {
+    loadSpotifyBtn.addEventListener("click", async () => {
+      try {
+        const playlists = await spotifyProvider.listPlaylists();
+        updateState({ source: "spotify", playlists });
+        rerender();
+      } catch (error) {
+        showError(error);
+      }
+    });
+  }
+
+  const importJsonLabel = sourceActions.querySelector("#import-json");
+  if (importJsonLabel) {
+    const input = importJsonLabel.querySelector("input");
+    input.addEventListener("change", async () => {
+      if (!input.files?.length) return;
+      const data = await importFromJSON(input.files[0]);
+      updateState({ source: data.source ?? "json", playlists: data.playlists ?? [] });
+      rerender();
+    });
+  }
+
+  const importCsvLabel = sourceActions.querySelector("#import-csv");
+  if (importCsvLabel) {
+    const input = importCsvLabel.querySelector("input");
+    input.addEventListener("change", async () => {
+      if (!input.files?.length) return;
+      const playlistsFile = Array.from(input.files).find((file) => file.name.includes("playlists"));
+      const tracksFile = Array.from(input.files).find((file) => file.name.includes("tracks"));
+      if (!playlistsFile || !tracksFile) {
+        showError(new Error("Please provide playlists.csv and tracks.csv"));
+        return;
+      }
+      const data = await importFromCSV({ playlists: playlistsFile, tracks: tracksFile });
+      updateState({ source: data.source, playlists: data.playlists });
+      rerender();
+    });
+  }
+
+  const exportJsonBtn = exportActions.querySelector("#export-json");
+  if (exportJsonBtn) {
+    exportJsonBtn.addEventListener("click", () => {
+      const state = getState();
+      exportAsJSON({ source: state.source, playlists: state.playlists, fetchedAt: Date.now() });
+    });
+  }
+  const exportCsvBtn = exportActions.querySelector("#export-csv");
+  if (exportCsvBtn) {
+    exportCsvBtn.addEventListener("click", () => {
+      const state = getState();
+      exportAsCSV({ source: state.source, playlists: state.playlists });
+    });
+  }
+}
+
+function attachPersistenceListeners(form) {
+  const enableBtn = form.querySelector("#enable-encrypted");
+  const disableBtn = form.querySelector("#disable-encrypted");
+  const passphraseInput = form.querySelector('input[name="passphrase"]');
+
+  const localActive = getState().settings.persistence === "local-encrypted";
+
+  if (enableBtn) {
+    if (localActive) enableBtn.textContent = "Unlock encrypted storage";
+    enableBtn.addEventListener("click", async () => {
+      const passphrase = passphraseInput?.value;
+      if (!passphrase) {
+        showToast("Enter a passphrase first");
+        return;
+      }
+      try {
+        if (localActive) {
+          const unlocked = await unlockEncryptedState(passphrase);
+          if (unlocked) showToast("Encrypted storage unlocked");
+          else showToast("Passphrase incorrect");
+        } else {
+          await setPersistence("local-encrypted", { passphrase });
+          showToast("Encrypted storage enabled");
+        }
+      } catch (error) {
+        showError(error);
+      }
+    });
+  }
+
+  if (disableBtn) {
+    disableBtn.addEventListener("click", async () => {
+      await setPersistence("session");
+      showToast("Reverted to session storage");
+    });
+  }
+
+  if (localActive) {
+    const banner = document.createElement("p");
+    banner.textContent = "Encrypted storage is active. Provide your passphrase to unlock this browser.";
+    form.appendChild(banner);
+  }
+}
+
+async function runAutoMapping() {
+  const state = getState();
+  const selectedPlaylists = state.playlists.filter((playlist) => state.selectedPlaylists.includes(playlist.id));
+  const pending = [];
+  const matches = { ...state.mapping.matches };
+  for (const playlist of selectedPlaylists) {
+    if (!playlist.tracks || !playlist.tracks.length) {
+      if (state.source === "spotify") {
+        try {
+          const tracks = await spotifyProvider.readTracks(playlist.id);
+          playlist.tracks = tracks;
+          const updated = state.playlists.map((p) => (p.id === playlist.id ? { ...p, tracks } : p));
+          updateState({ playlists: updated });
+        } catch (error) {
+          showError(error);
+        }
+      }
+    }
+    for (const track of playlist.tracks ?? []) {
+      const key = getTrackKey(track);
+      if (matches[key]) continue;
+      const candidates = await findCandidates(track, {
+        providerName: "youtube",
+        search: youtubeProvider.search,
+        locale: state.locale,
+      });
+      if (candidates.best) {
+        matches[key] = candidates.best.track;
+      } else {
+        pending.push({ track, candidates: candidates.candidates });
+      }
+    }
+  }
+  updateState({ mapping: { matches, pending, logs: [...state.mapping.logs, { level: "info", message: "Auto mapping completed", timestamp: Date.now() }] } });
+}
+
+async function startTransfer(progress) {
+  const state = getState();
+  const selectedPlaylists = state.playlists.filter((playlist) => state.selectedPlaylists.includes(playlist.id));
+  try {
+    await transferCollection({
+      collection: { source: state.source, playlists: selectedPlaylists },
+      target: {
+        providerName: "youtube",
+        createPlaylist: youtubeProvider.createPlaylist,
+        addItems: youtubeProvider.addItems,
+        search: youtubeProvider.search,
+      },
+    });
+    const newState = getState();
+    progress.setProgress(newState.transfer.processed, newState.transfer.total);
+  } catch (error) {
+    showError(error);
+  }
+}
+
+function renderNavState() {
+  const checkpoint = getCheckpoint();
+  const banner = document.querySelector("#resume-banner");
+  if (banner) banner.remove();
+  if (checkpoint) {
+    const element = document.createElement("div");
+    element.id = "resume-banner";
+    element.className = "lb-alert lb-alert-warning";
+    element.textContent = translate("resume_banner", getState().locale);
+    const resumeBtn = document.createElement("button");
+    resumeBtn.type = "button";
+    resumeBtn.className = "lb-button-secondary";
+    resumeBtn.textContent = "Resume";
+    resumeBtn.addEventListener("click", () => {
+      window.location.hash = "#/transfer";
+    });
+    const dismissBtn = document.createElement("button");
+    dismissBtn.type = "button";
+    dismissBtn.className = "lb-button-secondary";
+    dismissBtn.textContent = "Dismiss";
+    dismissBtn.addEventListener("click", () => {
+      clearCheckpoint();
+      renderNavState();
+    });
+    element.append(resumeBtn, dismissBtn);
+    document.body.insertBefore(element, document.body.firstChild);
+  }
+}
+
+function maybeResumeBanner() {
+  const checkpoint = getCheckpoint();
+  if (!checkpoint) return null;
+  const banner = document.createElement("div");
+  banner.className = "lb-alert lb-alert-warning";
+  banner.textContent = translate("resume_banner", getState().locale);
+  const resume = document.createElement("button");
+  resume.type = "button";
+  resume.className = "lb-button-secondary";
+  resume.textContent = "Resume";
+  resume.addEventListener("click", () => (window.location.hash = "#/transfer"));
+  banner.appendChild(resume);
+  return banner;
+}
+
+function setupThemeToggle() {
+  if (!themeToggle) return;
+  updateThemeToggleButton();
+  themeToggle.addEventListener("click", () => {
+    const current = document.documentElement.getAttribute("data-theme") ?? "system";
+    const next = current === "dark" ? "light" : current === "light" ? "system" : "dark";
+    document.documentElement.setAttribute("data-theme", next);
+    updateThemeToggleButton();
+  });
+}
+
+function updateThemeToggleButton() {
+  if (!themeToggle) return;
+  const current = document.documentElement.getAttribute("data-theme") ?? "system";
+  const icon = current === "dark" ? "🌙" : current === "light" ? "☀️" : "🌓";
+  const next = current === "dark" ? "light" : current === "light" ? "system" : "dark";
+  themeToggle.textContent = icon;
+  themeToggle.setAttribute("title", `Toggle color scheme (current: ${current}, next: ${next})`);
+  themeToggle.setAttribute("aria-label", `Toggle color scheme (next: ${next})`);
+}
+
+function showError(error) {
+  console.error(error);
+  showToast(error.message ?? "Unexpected error");
+}
+
+function showToast(message) {
+  const toast = document.createElement("div");
+  toast.className = "lb-alert lb-alert-warning";
+  toast.textContent = message;
+  document.body.appendChild(toast);
+  setTimeout(() => toast.remove(), 4000);
+}
+
+function getTrackKey(track) {
+  return track.sourceIds?.spotify ?? track.sourceIds?.youtube ?? track.id;
+}
+
+function exportFailures(failures) {
+  const rows = failures.map((item, index) => ({
+    index: index + 1,
+    title: item.track.title,
+    artists: item.track.artists?.join("; ") ?? "",
+    reason: item.reason,
+  }));
+  const csv = toCSV(rows);
+  downloadFile([csv], "transfer-failures.csv", "text/csv");
+}

--- a/src/auth/googleAuth.js
+++ b/src/auth/googleAuth.js
@@ -1,0 +1,65 @@
+import { prepareAuthorization, handleRedirect, persistToken, ensureFreshToken } from "./oauth.js";
+import { getConfig } from "../config.js";
+import { updateState, getState, setToken } from "../state.js";
+import { announce } from "../util.js";
+
+const STATE_KEY = "listbridge.google.oauth.state";
+
+/**
+ * Start Google OAuth flow for YouTube Data API.
+ */
+export async function authorizeGoogle() {
+  const config = getConfig().google;
+  if (!config.clientId) throw new Error("Google OAuth Client ID is not set. Add it on the Connect screen before signing in.");
+  const { url, state } = await prepareAuthorization({
+    authorizeEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+    clientId: config.clientId,
+    redirectUri: config.redirectUri,
+    scopes: config.scopes,
+    extraParams: {
+      access_type: "offline",
+      include_granted_scopes: "true",
+      prompt: "consent",
+    },
+  });
+  sessionStorage.setItem(STATE_KEY, state);
+  window.location.assign(url);
+}
+
+/**
+ * Handle Google OAuth redirect.
+ * @param {string} currentUrl
+ */
+export async function handleGoogleRedirect(currentUrl) {
+  const config = getConfig().google;
+  const expectedState = sessionStorage.getItem(STATE_KEY) ?? "";
+  const token = await handleRedirect({
+    currentUrl,
+    expectedState,
+    tokenEndpoint: "https://oauth2.googleapis.com/token",
+    clientId: config.clientId,
+    redirectUri: config.redirectUri,
+  });
+  if (!token) return null;
+  persistToken("google", token);
+  updateState({ user: { ...getState().user, google: { authenticatedAt: Date.now() } } });
+  announce("Google 계정이 연결되었습니다.");
+  return token;
+}
+
+/**
+ * Obtain latest Google access token.
+ * @returns {Promise<import("./oauth.js").TokenResponse | null>}
+ */
+export async function getGoogleToken() {
+  const config = getConfig().google;
+  return ensureFreshToken("google", {
+    tokenEndpoint: "https://oauth2.googleapis.com/token",
+    clientId: config.clientId,
+  });
+}
+
+export function disconnectGoogle() {
+  setToken("google", null);
+  updateState({ user: { ...getState().user, google: null } });
+}

--- a/src/auth/oauth.js
+++ b/src/auth/oauth.js
@@ -1,0 +1,184 @@
+import { fetchWithRetry, uid } from "../util.js";
+import { getToken, setToken } from "../state.js";
+
+/**
+ * @typedef {Object} PKCEChallenge
+ * @property {string} verifier
+ * @property {string} challenge
+ */
+
+/**
+ * @typedef {Object} TokenResponse
+ * @property {string} access_token
+ * @property {string} token_type
+ * @property {number} expires_in
+ * @property {string} [refresh_token]
+ * @property {string} [scope]
+ * @property {number} [expires_at]
+ */
+
+const PKCE_STORE_KEY = "listbridge.pkce";
+
+/**
+ * Generate PKCE verifier and challenge.
+ * @returns {Promise<PKCEChallenge>}
+ */
+export async function createPKCEChallenge() {
+  const verifier = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)));
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  const challenge = base64UrlEncode(new Uint8Array(digest));
+  return { verifier, challenge };
+}
+
+/**
+ * Build authorization URL.
+ * @param {{ authorizeEndpoint: string, clientId: string, redirectUri: string, scopes: string[], state?: string, extraParams?: Record<string, string> }} params
+ * @returns {{ url: string, state: string, verifier: string }}
+ */
+export async function prepareAuthorization(params) {
+  const { authorizeEndpoint, clientId, redirectUri, scopes, state = uid(), extraParams = {} } = params;
+  const pkce = await createPKCEChallenge();
+  const url = new URL(authorizeEndpoint);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("scope", scopes.join(" "));
+  url.searchParams.set("state", state);
+  url.searchParams.set("code_challenge", pkce.challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  Object.entries(extraParams).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+  storeVerifier(state, pkce.verifier);
+  return { url: url.toString(), state, verifier: pkce.verifier };
+}
+
+/**
+ * Handle redirect and exchange authorization code for tokens.
+ * @param {{ currentUrl: string, expectedState: string, tokenEndpoint: string, clientId: string, redirectUri: string }} params
+ * @returns {Promise<TokenResponse | null>}
+ */
+export async function handleRedirect(params) {
+  const { currentUrl, expectedState, tokenEndpoint, clientId, redirectUri } = params;
+  const parsed = new URL(currentUrl);
+  const code = parsed.searchParams.get("code");
+  const stateParam = parsed.searchParams.get("state");
+  const error = parsed.searchParams.get("error");
+  if (error) throw new Error(`Authorization error: ${error}`);
+  if (!code || !stateParam || stateParam !== expectedState) return null;
+  const verifier = consumeVerifier(stateParam);
+  if (!verifier) throw new Error("Missing PKCE verifier");
+  const token = await exchangeToken(tokenEndpoint, {
+    clientId,
+    code,
+    codeVerifier: verifier,
+    redirectUri,
+  });
+  return token;
+}
+
+/**
+ * Exchange authorization code for tokens.
+ * @param {string} tokenEndpoint
+ * @param {{ clientId: string, code: string, codeVerifier: string, redirectUri: string }} body
+ * @returns {Promise<TokenResponse>}
+ */
+export async function exchangeToken(tokenEndpoint, body) {
+  const payload = new URLSearchParams();
+  payload.set("grant_type", "authorization_code");
+  payload.set("client_id", body.clientId);
+  payload.set("code", body.code);
+  payload.set("code_verifier", body.codeVerifier);
+  payload.set("redirect_uri", body.redirectUri);
+
+  const response = await fetchWithRetry(tokenEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: payload.toString(),
+  });
+  const token = /** @type {TokenResponse} */ (await response.json());
+  token.expires_at = Date.now() + (token.expires_in - 30) * 1000;
+  return token;
+}
+
+/**
+ * Refresh an access token.
+ * @param {string} tokenEndpoint
+ * @param {{ clientId: string, refreshToken: string }} body
+ * @returns {Promise<TokenResponse>}
+ */
+export async function refreshToken(tokenEndpoint, body) {
+  const payload = new URLSearchParams();
+  payload.set("grant_type", "refresh_token");
+  payload.set("client_id", body.clientId);
+  payload.set("refresh_token", body.refreshToken);
+
+  const response = await fetchWithRetry(tokenEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: payload.toString(),
+  });
+  const token = /** @type {TokenResponse} */ (await response.json());
+  token.refresh_token = token.refresh_token ?? body.refreshToken;
+  token.expires_at = Date.now() + (token.expires_in - 30) * 1000;
+  return token;
+}
+
+/**
+ * Determine if the token is expired.
+ * @param {TokenResponse | null} token
+ */
+export function isExpired(token) {
+  if (!token || !token.expires_at) return true;
+  return Date.now() > token.expires_at;
+}
+
+/**
+ * Ensure token is fresh, refreshing when necessary.
+ * @param {'spotify' | 'google'} provider
+ * @param {{ tokenEndpoint: string, clientId: string }} config
+ * @returns {Promise<TokenResponse | null>}
+ */
+export async function ensureFreshToken(provider, config) {
+  const token = getToken(provider);
+  if (!token) return null;
+  if (!isExpired(token)) return token;
+  if (!token.refresh_token) return null;
+  const refreshed = await refreshToken(config.tokenEndpoint, {
+    clientId: config.clientId,
+    refreshToken: token.refresh_token,
+  });
+  setToken(provider, refreshed);
+  return refreshed;
+}
+
+/**
+ * Persist token in state storage.
+ * @param {'spotify' | 'google'} provider
+ * @param {TokenResponse} token
+ */
+export function persistToken(provider, token) {
+  setToken(provider, token);
+}
+
+function storeVerifier(state, verifier) {
+  const existing = JSON.parse(sessionStorage.getItem(PKCE_STORE_KEY) ?? "{}");
+  existing[state] = verifier;
+  sessionStorage.setItem(PKCE_STORE_KEY, JSON.stringify(existing));
+}
+
+function consumeVerifier(state) {
+  const existing = JSON.parse(sessionStorage.getItem(PKCE_STORE_KEY) ?? "{}");
+  const verifier = existing[state];
+  delete existing[state];
+  sessionStorage.setItem(PKCE_STORE_KEY, JSON.stringify(existing));
+  return verifier;
+}
+
+function base64UrlEncode(bytes) {
+  let binary = "";
+  bytes.forEach((b) => (binary += String.fromCharCode(b)));
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/src/auth/spotifyAuth.js
+++ b/src/auth/spotifyAuth.js
@@ -1,0 +1,60 @@
+import { prepareAuthorization, handleRedirect, persistToken, ensureFreshToken } from "./oauth.js";
+import { getConfig } from "../config.js";
+import { updateState, getState, setToken } from "../state.js";
+import { announce } from "../util.js";
+
+const STATE_KEY = "listbridge.spotify.oauth.state";
+
+/**
+ * Launch Spotify authorization flow.
+ */
+export async function authorizeSpotify() {
+  const config = getConfig().spotify;
+  if (!config.clientId) throw new Error("Spotify Client ID is not set. Add it on the Connect screen before signing in.");
+  const { url, state } = await prepareAuthorization({
+    authorizeEndpoint: "https://accounts.spotify.com/authorize",
+    clientId: config.clientId,
+    redirectUri: config.redirectUri,
+    scopes: config.scopes,
+  });
+  sessionStorage.setItem(STATE_KEY, state);
+  window.location.assign(url);
+}
+
+/**
+ * Handle Spotify redirect on callback page.
+ * @param {string} currentUrl
+ */
+export async function handleSpotifyRedirect(currentUrl) {
+  const config = getConfig().spotify;
+  const expectedState = sessionStorage.getItem(STATE_KEY) ?? "";
+  const token = await handleRedirect({
+    currentUrl,
+    expectedState,
+    tokenEndpoint: "https://accounts.spotify.com/api/token",
+    clientId: config.clientId,
+    redirectUri: config.redirectUri,
+  });
+  if (!token) return null;
+  persistToken("spotify", token);
+  updateState({ user: { ...getState().user, spotify: { authenticatedAt: Date.now() } } });
+  announce("Spotify 연결이 완료되었습니다.");
+  return token;
+}
+
+/**
+ * Refresh token if needed and return latest access token.
+ * @returns {Promise<import("./oauth.js").TokenResponse | null>}
+ */
+export async function getSpotifyToken() {
+  const config = getConfig().spotify;
+  return ensureFreshToken("spotify", {
+    tokenEndpoint: "https://accounts.spotify.com/api/token",
+    clientId: config.clientId,
+  });
+}
+
+export function disconnectSpotify() {
+  setToken("spotify", null);
+  updateState({ user: { ...getState().user, spotify: null } });
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,40 @@
+const origin = typeof window !== "undefined" ? window.location.origin : "";
+const basePath =
+  typeof window !== "undefined"
+    ? window.location.pathname.replace(/index\.html?$/, "")
+    : "/";
+
+const baseConfig = {
+  appVersion: "1.0.0",
+  spotify: {
+    redirectUri: `${origin}${basePath}callback/spotify`,
+    scopes: [
+      "playlist-read-private",
+      "user-library-read",
+      "playlist-modify-private",
+      "playlist-modify-public",
+    ],
+  },
+  google: {
+    redirectUri: `${origin}${basePath}callback/google`,
+    scopes: [
+      "https://www.googleapis.com/auth/youtube",
+    ],
+  },
+};
+
+const runtimeConfig = typeof globalThis !== "undefined" && globalThis.OAUTH_CONFIG
+  ? globalThis.OAUTH_CONFIG
+  : {};
+
+export function getConfig() {
+  const spotifyOverrides = runtimeConfig.spotify ?? {};
+  const googleOverrides = runtimeConfig.google ?? {};
+  const appOverrides = runtimeConfig.app ?? {};
+  return {
+    ...baseConfig,
+    ...appOverrides,
+    spotify: { ...baseConfig.spotify, ...spotifyOverrides },
+    google: { ...baseConfig.google, ...googleOverrides },
+  };
+}

--- a/src/mapping/normalizer.js
+++ b/src/mapping/normalizer.js
@@ -1,0 +1,91 @@
+import { STOPWORDS, FEATURE_WORDS, VERSION_TAGS, TOKEN_OPTIONS } from "./rules.js";
+
+/**
+ * Normalize text by lowering, trimming, removing punctuation and version tags.
+ * @param {string} text
+ * @param {string} [locale]
+ * @returns {string}
+ */
+export function normalizeText(text, locale = "en") {
+  if (!text) return "";
+  const lower = text
+    .toLowerCase()
+    .replace(/\([^)]*\)|\[[^\]]*\]/g, (match) => (containsVersionTag(match) ? "" : match))
+    .replace(/feat\.|ft\.|featuring/gi, " feat ")
+    .replace(/["'`]/g, "")
+    .replace(/&/g, " and ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const stopwords = STOPWORDS[locale] ?? [];
+  const filtered = lower
+    .split(TOKEN_OPTIONS.separators)
+    .filter((token) => token && !stopwords.includes(token))
+    .join(" ");
+  return filtered.trim();
+}
+
+function containsVersionTag(text) {
+  const lower = text.toLowerCase();
+  return VERSION_TAGS.some((tag) => lower.includes(tag));
+}
+
+/**
+ * Normalize artists list by splitting featuring terms.
+ * @param {string[]} artists
+ * @returns {string[]}
+ */
+export function normalizeArtists(artists) {
+  const normalized = [];
+  for (const artist of artists ?? []) {
+    const tokens = artist
+      .replace(/&/g, ",")
+      .replace(/feat\.|ft\.|featuring/gi, ",")
+      .split(/[,|]/)
+      .map((token) => token.trim())
+      .filter(Boolean);
+    tokens.forEach((token) => normalized.push(token.toLowerCase()));
+  }
+  return Array.from(new Set(normalized));
+}
+
+/**
+ * Normalize track metadata.
+ * @param {import("../providers/provider.types.js").TrackSummary} track
+ * @param {string} [locale]
+ */
+export function normalizeTrack(track, locale = "en") {
+  return {
+    ...track,
+    normalizedTitle: normalizeText(track.title, locale),
+    normalizedArtists: normalizeArtists(track.artists),
+  };
+}
+
+/**
+ * Build token set from normalized string.
+ * @param {string} text
+ * @returns {Set<string>}
+ */
+export function tokenize(text) {
+  return new Set(text.split(TOKEN_OPTIONS.separators).filter(Boolean));
+}
+
+/**
+ * Identify featuring artists from the original string.
+ * @param {string} text
+ * @returns {string[]}
+ */
+export function extractFeaturing(text) {
+  const lower = text.toLowerCase();
+  for (const keyword of FEATURE_WORDS) {
+    const index = lower.indexOf(keyword);
+    if (index >= 0) {
+      const substring = lower.slice(index + keyword.length);
+      return substring
+        .split(/[,&]/)
+        .map((part) => part.replace(/[^a-z0-9가-힣 ]/gi, "").trim())
+        .filter(Boolean);
+    }
+  }
+  return [];
+}

--- a/src/mapping/rules.js
+++ b/src/mapping/rules.js
@@ -1,0 +1,32 @@
+export const STOPWORDS = {
+  en: ["remastered", "remaster", "live", "version", "official", "audio", "video"],
+  ko: ["라이브", "버전", "공식", "오디오"],
+};
+
+export const FEATURE_WORDS = ["feat", "featuring", "ft", "with"];
+
+export const VERSION_TAGS = [
+  "remaster",
+  "remastered",
+  "remastering",
+  "live",
+  "acoustic",
+  "instrumental",
+  "official video",
+  "official audio",
+  "lyrics",
+  "lyric",
+  "mv",
+  "m/v",
+];
+
+export const YEAR_TOLERANCE = 2;
+
+export const SCORE_THRESHOLDS = {
+  auto: 75,
+  review: 60,
+};
+
+export const TOKEN_OPTIONS = {
+  separators: /[\s,;:\-\/\[\]()]+/g,
+};

--- a/src/mapping/scorer.js
+++ b/src/mapping/scorer.js
@@ -1,0 +1,127 @@
+import { normalizeTrack, tokenize } from "./normalizer.js";
+import { YEAR_TOLERANCE } from "./rules.js";
+
+/**
+ * Compute a similarity score between two tracks.
+ * @param {import("../providers/provider.types.js").TrackSummary} source
+ * @param {import("../providers/provider.types.js").TrackSummary} candidate
+ * @param {{ locale?: string }} [options]
+ * @returns {{ score: number, breakdown: Record<string, number> }}
+ */
+export function scoreMatch(source, candidate, options = {}) {
+  const locale = options.locale ?? "en";
+  const normalizedSource = normalizeTrack(source, locale);
+  const normalizedCandidate = normalizeTrack(candidate, locale);
+
+  const titleScore = computeTitleScore(normalizedSource.normalizedTitle, normalizedCandidate.normalizedTitle);
+  const artistScore = computeArtistScore(normalizedSource.normalizedArtists, normalizedCandidate.normalizedArtists);
+  const durationScore = computeDurationScore(source.duration_ms, candidate.duration_ms);
+  const yearScore = computeYearScore(source.release_year, candidate.release_year);
+  const explicitScore = computeExplicitScore(source.explicit, candidate.explicit);
+
+  const score = titleScore + artistScore + durationScore + yearScore + explicitScore;
+  return {
+    score,
+    breakdown: {
+      title: titleScore,
+      artist: artistScore,
+      duration: durationScore,
+      year: yearScore,
+      explicit: explicitScore,
+    },
+  };
+}
+
+function computeTitleScore(a, b) {
+  if (!a || !b) return 0;
+  const jw = jaroWinkler(a, b);
+  const token = tokenSetRatio(a, b);
+  return Math.round((jw * 0.6 + token * 0.4) * 50);
+}
+
+function computeArtistScore(a, b) {
+  if (!a?.length || !b?.length) return 0;
+  const setA = new Set(a);
+  const setB = new Set(b);
+  const intersection = [...setA].filter((value) => setB.has(value));
+  const union = new Set([...setA, ...setB]).size;
+  const ratio = intersection.length / union;
+  return Math.round(ratio * 30);
+}
+
+function computeDurationScore(a, b) {
+  if (!a || !b) return 0;
+  const diff = Math.abs(a - b);
+  if (diff <= 2000) return 10;
+  if (diff >= 20000) return 0;
+  return Math.max(0, Math.round(10 - diff / 2000));
+}
+
+function computeYearScore(a, b) {
+  if (!a || !b) return 0;
+  const diff = Math.abs(a - b);
+  if (diff > YEAR_TOLERANCE) return 0;
+  return Math.round(5 - diff * 2.5);
+}
+
+function computeExplicitScore(a, b) {
+  if (a === undefined || b === undefined) return 0;
+  return a === b ? 5 : 0;
+}
+
+function tokenSetRatio(a, b) {
+  const setA = tokenize(a);
+  const setB = tokenize(b);
+  const intersection = [...setA].filter((value) => setB.has(value));
+  const ratio = intersection.length / Math.max(setA.size, setB.size, 1);
+  const jw = jaroWinkler(a, b);
+  return (ratio * 0.5 + jw * 0.5);
+}
+
+function jaroWinkler(a, b) {
+  if (a === b) return 1;
+  const aLen = a.length;
+  const bLen = b.length;
+  if (aLen === 0 || bLen === 0) return 0;
+  const matchDistance = Math.floor(Math.max(aLen, bLen) / 2) - 1;
+
+  const aMatches = new Array(aLen).fill(false);
+  const bMatches = new Array(bLen).fill(false);
+  let matches = 0;
+  let transpositions = 0;
+
+  for (let i = 0; i < aLen; i += 1) {
+    const start = Math.max(0, i - matchDistance);
+    const end = Math.min(i + matchDistance + 1, bLen);
+    for (let j = start; j < end; j += 1) {
+      if (bMatches[j]) continue;
+      if (a[i] !== b[j]) continue;
+      aMatches[i] = true;
+      bMatches[j] = true;
+      matches += 1;
+      break;
+    }
+  }
+
+  if (matches === 0) return 0;
+
+  let k = 0;
+  for (let i = 0; i < aLen; i += 1) {
+    if (!aMatches[i]) continue;
+    while (!bMatches[k]) k += 1;
+    if (a[i] !== b[k]) transpositions += 1;
+    k += 1;
+  }
+
+  const jaro =
+    (matches / aLen + matches / bLen + (matches - transpositions / 2) / matches) / 3;
+
+  let prefix = 0;
+  const maxPrefix = 4;
+  for (let i = 0; i < Math.min(maxPrefix, aLen, bLen); i += 1) {
+    if (a[i] === b[i]) prefix += 1;
+    else break;
+  }
+
+  return jaro + prefix * 0.1 * (1 - jaro);
+}

--- a/src/mapping/searcher.js
+++ b/src/mapping/searcher.js
@@ -1,0 +1,73 @@
+import { LRUCache } from "../util.js";
+import { normalizeTrack, extractFeaturing } from "./normalizer.js";
+import { scoreMatch } from "./scorer.js";
+import { SCORE_THRESHOLDS } from "./rules.js";
+
+const cache = new LRUCache(200);
+
+/**
+ * Search target provider for candidate matches.
+ * @param {import("../providers/provider.types.js").TrackSummary} sourceTrack
+ * @param {{ providerName: string, search: (query: string) => Promise<import("../providers/provider.types.js").TrackSummary[]>, locale?: string }} context
+ * @returns {Promise<{ best?: CandidateScore, candidates: CandidateScore[] }>}
+ */
+export async function findCandidates(sourceTrack, context) {
+  const locale = context.locale ?? "en";
+  const normalized = normalizeTrack(sourceTrack, locale);
+  const queries = buildQueries(normalized);
+  /** @type {Map<string, CandidateScore>} */
+  const candidateMap = new Map();
+
+  for (const query of queries) {
+    const key = `${context.providerName}:${query}`;
+    /** @type {import("../providers/provider.types.js").TrackSummary[]} */
+    let results = cache.get(key);
+    if (!results) {
+      results = await context.search(query);
+      cache.set(key, results);
+    }
+    for (const result of results) {
+      const uniqueId = result.sourceIds?.[context.providerName] ?? result.id;
+      if (!uniqueId || candidateMap.has(uniqueId)) continue;
+      const scored = scoreMatch(sourceTrack, result, { locale });
+      candidateMap.set(uniqueId, {
+        track: result,
+        score: scored.score,
+        breakdown: scored.breakdown,
+      });
+    }
+  }
+
+  const candidates = [...candidateMap.values()].sort((a, b) => b.score - a.score);
+  const best = candidates[0];
+  return {
+    best: best && best.score >= SCORE_THRESHOLDS.auto ? best : undefined,
+    candidates,
+  };
+}
+
+/**
+ * Build prioritized search queries.
+ * @param {ReturnType<typeof normalizeTrack>} track
+ * @returns {string[]}
+ */
+function buildQueries(track) {
+  const base = `${track.normalizedArtists[0] ?? ""} - ${track.normalizedTitle}`.trim();
+  const queries = [base];
+  if (track.normalizedArtists.length > 1) {
+    queries.push(`${track.normalizedArtists.join(" ")} ${track.normalizedTitle}`);
+  }
+  const features = extractFeaturing(track.title ?? "");
+  if (features.length) {
+    queries.push(`${track.normalizedTitle} ${features.join(" ")}`);
+  }
+  queries.push(track.normalizedTitle);
+  return Array.from(new Set(queries.filter(Boolean)));
+}
+
+/**
+ * @typedef {Object} CandidateScore
+ * @property {import("../providers/provider.types.js").TrackSummary} track
+ * @property {number} score
+ * @property {Record<string, number>} breakdown
+ */

--- a/src/providers/_template.js
+++ b/src/providers/_template.js
@@ -1,0 +1,62 @@
+/**
+ * Provider template for extending ListBridge with new music services.
+ * Copy this file, rename it (e.g. appleMusic.js) and implement all exported
+ * functions. Register the provider in the UI by dynamically importing the module.
+ */
+
+/**
+ * Describe provider capabilities and metadata.
+ * @returns {import("./provider.types.js").ProviderCapabilities}
+ */
+export function getCapabilities() {
+  return {
+    supportsPlaylistCreate: false,
+    supportsTrackAdd: false,
+    supportsSearch: false,
+    displayName: "Template Provider",
+  };
+}
+
+/**
+ * Fetch playlists for the authenticated user.
+ * @returns {Promise<import("./provider.types.js").PlaylistSummary[]>}
+ */
+export async function listPlaylists() {
+  throw new Error("Not implemented");
+}
+
+/**
+ * Fetch tracks for a specific playlist.
+ * @param {string} playlistId
+ * @returns {Promise<import("./provider.types.js").TrackSummary[]>}
+ */
+export async function readTracks(playlistId) {
+  throw new Error("Not implemented");
+}
+
+/**
+ * Create a playlist in the target service.
+ * @param {{ name: string, description?: string, visibility?: 'public' | 'private' }} options
+ * @returns {Promise<{ id: string }>}
+ */
+export async function createPlaylist(options) {
+  throw new Error("Not implemented");
+}
+
+/**
+ * Add items to a playlist.
+ * @param {string} playlistId
+ * @param {string[]} ids
+ */
+export async function addItems(playlistId, ids) {
+  throw new Error("Not implemented");
+}
+
+/**
+ * Search tracks on the target service.
+ * @param {string} query
+ * @returns {Promise<import("./provider.types.js").TrackSummary[]>}
+ */
+export async function search(query) {
+  throw new Error("Not implemented");
+}

--- a/src/providers/provider.types.js
+++ b/src/providers/provider.types.js
@@ -1,0 +1,42 @@
+/**
+ * @typedef {Object} PlaylistSummary
+ * @property {string} id
+ * @property {string} name
+ * @property {string} [description]
+ * @property {string} [coverUrl]
+ * @property {number} [trackCount]
+ */
+
+/**
+ * @typedef {Object} TrackSummary
+ * @property {string} id
+ * @property {string} title
+ * @property {string[]} artists
+ * @property {string} [album]
+ * @property {number} [duration_ms]
+ * @property {string} [isrc]
+ * @property {number} [release_year]
+ * @property {boolean} [explicit]
+ * @property {string} [coverUrl]
+ * @property {Record<string, string>} [sourceIds]
+ */
+
+/**
+ * @typedef {Object} ProviderCapabilities
+ * @property {boolean} supportsPlaylistCreate
+ * @property {boolean} supportsTrackAdd
+ * @property {boolean} supportsSearch
+ * @property {string} displayName
+ */
+
+/**
+ * @typedef {Object} ProviderClient
+ * @property {() => Promise<PlaylistSummary[]>} listPlaylists
+ * @property {(playlistId: string) => Promise<TrackSummary[]>} readTracks
+ * @property {(options: { name: string, description?: string, visibility?: 'public' | 'private' }) => Promise<{ id: string }>} createPlaylist
+ * @property {(playlistId: string, trackUris: string[]) => Promise<void>} addItems
+ * @property {(query: string) => Promise<TrackSummary[]>} search
+ * @property {() => ProviderCapabilities} getCapabilities
+ */
+
+export {};

--- a/src/providers/spotify.js
+++ b/src/providers/spotify.js
@@ -1,0 +1,146 @@
+import { fetchWithRetry, withBackoff } from "../util.js";
+import { getState, setToken } from "../state.js";
+import { getSpotifyToken } from "../auth/spotifyAuth.js";
+
+const API_BASE = "https://api.spotify.com/v1";
+
+let cachedUser;
+
+async function apiRequest(path, options = {}) {
+  const stateToken = getState().tokens.spotify;
+  const token = (await getSpotifyToken()) ?? stateToken;
+  if (!token) throw new Error("Spotify authentication required");
+  const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
+  const response = await fetchWithRetry(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token.access_token}`,
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  if (response.status === 401) {
+    setToken("spotify", null);
+    throw new Error("Spotify token expired");
+  }
+  if (response.status === 204) return null;
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(`Spotify API error ${response.status}: ${body.error?.message ?? "Unknown"}`);
+  }
+  return response.json();
+}
+
+async function ensureUserProfile() {
+  if (cachedUser) return cachedUser;
+  cachedUser = await apiRequest("/me");
+  return cachedUser;
+}
+
+export async function listPlaylists() {
+  /** @type {import("./provider.types.js").PlaylistSummary[]} */
+  const playlists = [];
+  let next = "/me/playlists?limit=50";
+  while (next) {
+    const response = await apiRequest(next);
+    response.items.forEach((item) => {
+      playlists.push({
+        id: item.id,
+        name: item.name,
+        description: item.description,
+        coverUrl: item.images?.[0]?.url,
+        trackCount: item.tracks?.total ?? 0,
+      });
+    });
+    next = response.next;
+  }
+  return playlists;
+}
+
+export async function readTracks(playlistId) {
+  /** @type {import("./provider.types.js").TrackSummary[]} */
+  const tracks = [];
+  let next = `${API_BASE}/playlists/${playlistId}/tracks?limit=100`;
+  while (next) {
+    const response = await apiRequest(next);
+    response.items.forEach((item) => {
+      if (!item.track) return;
+      const track = item.track;
+      tracks.push({
+        id: track.id,
+        title: track.name,
+        artists: track.artists?.map((artist) => artist.name) ?? [],
+        album: track.album?.name,
+        duration_ms: track.duration_ms,
+        isrc: track.external_ids?.isrc,
+        release_year: track.album?.release_date ? Number(track.album.release_date.slice(0, 4)) : undefined,
+        explicit: track.explicit,
+        coverUrl: track.album?.images?.[0]?.url,
+        sourceIds: { spotify: track.uri },
+      });
+    });
+    next = response.next;
+  }
+  return tracks;
+}
+
+export async function createPlaylist(options) {
+  const user = await ensureUserProfile();
+  const payload = {
+    name: options.name,
+    description: options.description,
+    public: options.visibility === "public",
+  };
+  const response = await apiRequest(`/users/${user.id}/playlists`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  return { id: response.id };
+}
+
+export async function addItems(playlistId, trackUris) {
+  const chunks = chunk(trackUris, 100);
+  for (const uris of chunks) {
+    await withBackoff(() =>
+      apiRequest(`/playlists/${playlistId}/tracks`, {
+        method: "POST",
+        body: JSON.stringify({ uris }),
+      })
+    );
+  }
+}
+
+export async function search(query) {
+  const params = new URLSearchParams({ q: query, type: "track", limit: "10" });
+  const response = await apiRequest(`/search?${params.toString()}`);
+  const tracks = response.tracks?.items ?? [];
+  return tracks.map((track) => ({
+    id: track.id,
+    title: track.name,
+    artists: track.artists?.map((artist) => artist.name) ?? [],
+    album: track.album?.name,
+    duration_ms: track.duration_ms,
+    release_year: track.album?.release_date ? Number(track.album.release_date.slice(0, 4)) : undefined,
+    explicit: track.explicit,
+    coverUrl: track.album?.images?.[0]?.url,
+    sourceIds: { spotify: track.uri },
+  }));
+}
+
+export function getCapabilities() {
+  return {
+    supportsPlaylistCreate: true,
+    supportsTrackAdd: true,
+    supportsSearch: true,
+    displayName: "Spotify",
+  };
+}
+
+function chunk(arr, size) {
+  /** @type {string[][]} */
+  const result = [];
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}

--- a/src/providers/youtube.js
+++ b/src/providers/youtube.js
@@ -1,0 +1,200 @@
+import { fetchWithRetry, withBackoff } from "../util.js";
+import { getState, setToken } from "../state.js";
+import { getGoogleToken } from "../auth/googleAuth.js";
+
+const API_BASE = "https://www.googleapis.com/youtube/v3";
+
+const QUOTA_COST = {
+  playlistList: 1,
+  playlistInsert: 50,
+  playlistItemsList: 1,
+  playlistItemsInsert: 50,
+  searchList: 100,
+  videosList: 1,
+};
+
+let quotaUsed = 0;
+
+function trackQuota(cost) {
+  quotaUsed += cost;
+}
+
+export function getQuotaUsage() {
+  const daily = 10_000;
+  return {
+    used: quotaUsed,
+    remaining: Math.max(0, daily - quotaUsed),
+    daily,
+  };
+}
+
+async function apiRequest(path, options = {}) {
+  const stateToken = getState().tokens.google;
+  const token = (await getGoogleToken()) ?? stateToken;
+  if (!token) throw new Error("Google authentication required");
+  const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
+  const response = await fetchWithRetry(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token.access_token}`,
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  if (response.status === 401) {
+    setToken("google", null);
+    throw new Error("Google token expired");
+  }
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(`YouTube API error ${response.status}: ${body.error?.message ?? "Unknown"}`);
+  }
+  trackQuota(deriveQuotaCost(path, options.method ?? "GET"));
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+function deriveQuotaCost(path, method) {
+  if (path.includes("playlists?")) return QUOTA_COST.playlistList;
+  if (path.includes("playlists") && method === "POST") return QUOTA_COST.playlistInsert;
+  if (path.includes("playlistItems?")) return QUOTA_COST.playlistItemsList;
+  if (path.includes("playlistItems") && method === "POST") return QUOTA_COST.playlistItemsInsert;
+  if (path.includes("search")) return QUOTA_COST.searchList;
+  if (path.includes("videos")) return QUOTA_COST.videosList;
+  return 1;
+}
+
+export async function listPlaylists() {
+  /** @type {import("./provider.types.js").PlaylistSummary[]} */
+  const playlists = [];
+  let nextPageToken = "";
+  do {
+    const params = new URLSearchParams({
+      part: "snippet,contentDetails",
+      mine: "true",
+      maxResults: "50",
+    });
+    if (nextPageToken) params.set("pageToken", nextPageToken);
+    const response = await apiRequest(`/playlists?${params.toString()}`);
+    response.items?.forEach((item) => {
+      playlists.push({
+        id: item.id,
+        name: item.snippet.title,
+        description: item.snippet.description,
+        coverUrl: item.snippet.thumbnails?.standard?.url ?? item.snippet.thumbnails?.high?.url,
+        trackCount: item.contentDetails?.itemCount ?? 0,
+      });
+    });
+    nextPageToken = response.nextPageToken;
+  } while (nextPageToken);
+  return playlists;
+}
+
+export async function readTracks(playlistId) {
+  /** @type {import("./provider.types.js").TrackSummary[]} */
+  const tracks = [];
+  let nextPageToken = "";
+  do {
+    const params = new URLSearchParams({
+      part: "snippet,contentDetails",
+      playlistId,
+      maxResults: "50",
+    });
+    if (nextPageToken) params.set("pageToken", nextPageToken);
+    const response = await apiRequest(`/playlistItems?${params.toString()}`);
+    for (const item of response.items ?? []) {
+      const snippet = item.snippet;
+      if (!snippet?.resourceId) continue;
+      tracks.push({
+        id: snippet.resourceId.videoId,
+        title: snippet.title,
+        artists: snippet.videoOwnerChannelTitle ? [snippet.videoOwnerChannelTitle] : [],
+        album: snippet.channelTitle,
+        duration_ms: undefined,
+        explicit: false,
+        coverUrl: snippet.thumbnails?.medium?.url ?? snippet.thumbnails?.high?.url,
+        sourceIds: { youtube: snippet.resourceId.videoId },
+      });
+    }
+    nextPageToken = response.nextPageToken;
+  } while (nextPageToken);
+  return tracks;
+}
+
+export async function createPlaylist(options) {
+  const body = {
+    snippet: {
+      title: options.name,
+      description: options.description,
+    },
+    status: {
+      privacyStatus: options.visibility === "public" ? "public" : "private",
+    },
+  };
+  const params = new URLSearchParams({ part: "snippet,status" });
+  const response = await apiRequest(`/playlists?${params.toString()}`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  return { id: response.id };
+}
+
+export async function addItems(playlistId, videoIds) {
+  for (const videoId of videoIds) {
+    await withBackoff(() =>
+      apiRequest(`/playlistItems?part=snippet`, {
+        method: "POST",
+        body: JSON.stringify({
+          snippet: {
+            playlistId,
+            resourceId: {
+              kind: "youtube#video",
+              videoId,
+            },
+          },
+        }),
+      })
+    );
+  }
+}
+
+export async function search(query) {
+  const params = new URLSearchParams({
+    part: "snippet",
+    q: query,
+    type: "video",
+    maxResults: "10",
+  });
+  const response = await apiRequest(`/search?${params.toString()}`);
+  const ids = response.items?.map((item) => item.id?.videoId).filter(Boolean) ?? [];
+  if (!ids.length) return [];
+  const details = await apiRequest(`/videos?part=snippet,contentDetails&id=${ids.join(",")}`);
+  return details.items.map((item) => ({
+    id: item.id,
+    title: item.snippet.title,
+    artists: item.snippet.videoOwnerChannelTitle ? [item.snippet.videoOwnerChannelTitle] : [],
+    album: item.snippet.channelTitle,
+    duration_ms: parseISODuration(item.contentDetails?.duration ?? "PT0S"),
+    explicit: item.contentDetails?.contentRating?.ytRating === "ytAgeRestricted",
+    coverUrl: item.snippet.thumbnails?.high?.url,
+    sourceIds: { youtube: item.id },
+  }));
+}
+
+export function getCapabilities() {
+  return {
+    supportsPlaylistCreate: true,
+    supportsTrackAdd: true,
+    supportsSearch: true,
+    displayName: "YouTube",
+  };
+}
+
+function parseISODuration(duration) {
+  const match = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/.exec(duration);
+  if (!match) return 0;
+  const hours = Number(match[1] ?? 0);
+  const minutes = Number(match[2] ?? 0);
+  const seconds = Number(match[3] ?? 0);
+  return (hours * 3600 + minutes * 60 + seconds) * 1000;
+}

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,323 @@
+import { deepMerge, safeJsonParse, stringToBuffer } from "./util.js";
+
+const STORAGE_KEY = "listbridge.state.v1";
+const TOKEN_KEY = "listbridge.tokens.v1";
+const RESUME_KEY = "listbridge.resume.v1";
+const PERSIST_KEY = "listbridge.persistence.v1";
+
+const defaultState = Object.freeze({
+  locale: navigator.language.startsWith("ko") ? "ko" : "en",
+  theme: "system",
+  initialized: false,
+  settings: {
+    persistence: "session",
+    rememberTokens: false,
+  },
+  tokens: {
+    spotify: null,
+    google: null,
+  },
+  user: {
+    spotify: null,
+    google: null,
+  },
+  source: null,
+  playlists: [],
+  selectedPlaylists: [],
+  mapping: {
+    normalized: {},
+    matches: {},
+    pending: [],
+    failed: [],
+    logs: [],
+  },
+  transfer: {
+    status: "idle",
+    progress: 0,
+    total: 0,
+    processed: 0,
+    failures: [],
+    report: null,
+  },
+});
+
+/** @type {typeof defaultState} */
+let state = structuredClone(defaultState);
+
+/** @type {Set<(state: typeof state) => void>} */
+const subscribers = new Set();
+
+/** @type {{ mode: 'session' | 'local-encrypted', key?: CryptoKey, salt?: string }} */
+let persistence = {
+  mode: "session",
+};
+
+let initialLoadPromise;
+
+/**
+ * Initialize the global state by reading from storage.
+ * @returns {Promise<void>}
+ */
+export function initState() {
+  if (!initialLoadPromise) {
+    initialLoadPromise = (async () => {
+      const preference = safeJsonParse(localStorage.getItem(PERSIST_KEY), { mode: "session" });
+      if (preference && preference.mode === "local-encrypted") {
+        persistence.mode = "local-encrypted";
+      }
+
+      const sessionSnapshot = safeJsonParse(sessionStorage.getItem(STORAGE_KEY), null);
+      if (sessionSnapshot) {
+        applySnapshot(sessionSnapshot);
+        const sessionTokens = safeJsonParse(sessionStorage.getItem(TOKEN_KEY), null);
+        if (sessionTokens) state.tokens = sessionTokens;
+      } else if (persistence.mode === "local-encrypted") {
+        state.settings.persistence = "local-encrypted";
+        state.settings.rememberTokens = true;
+      }
+
+      state.initialized = true;
+      notify();
+    })();
+  }
+  return initialLoadPromise;
+}
+
+/**
+ * Subscribe to state changes.
+ * @param {(state: typeof state) => void} listener
+ * @returns {() => void}
+ */
+export function subscribe(listener) {
+  subscribers.add(listener);
+  return () => subscribers.delete(listener);
+}
+
+function notify() {
+  subscribers.forEach((listener) => listener(state));
+}
+
+/**
+ * Get the current state snapshot.
+ * @returns {typeof state}
+ */
+export function getState() {
+  return state;
+}
+
+/**
+ * Update the global state by merging the provided patch.
+ * @param {Partial<typeof state>} patch
+ */
+export function updateState(patch) {
+  state = deepMerge(state, patch);
+  persistState();
+  notify();
+}
+
+/**
+ * Reset the application state and storage.
+ */
+export function resetState() {
+  state = structuredClone(defaultState);
+  sessionStorage.removeItem(STORAGE_KEY);
+  sessionStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(STORAGE_KEY);
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(RESUME_KEY);
+  notify();
+}
+
+function applySnapshot(snapshot) {
+  state = deepMerge(structuredClone(defaultState), snapshot);
+}
+
+function persistState() {
+  const snapshot = {
+    ...state,
+    tokens: { spotify: null, google: null },
+  };
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+  if (state.settings.persistence === "local-encrypted" && persistence.mode === "local-encrypted" && persistence.key) {
+    const payload = JSON.stringify({
+      snapshot,
+      tokens: state.tokens,
+    });
+    encryptAndStore(payload, STORAGE_KEY, TOKEN_KEY).catch((error) => {
+      console.error("Failed to persist encrypted state", error);
+    });
+  }
+  sessionStorage.setItem(TOKEN_KEY, JSON.stringify(state.tokens));
+  if (state.settings.persistence === "session") {
+    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(TOKEN_KEY);
+  }
+}
+
+async function encryptAndStore(payload, stateKey, tokenKey) {
+  if (!persistence.key) return;
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const data = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    persistence.key,
+    stringToBuffer(payload)
+  );
+  const encoded = {
+    iv: arrayBufferToBase64(iv.buffer),
+    data: arrayBufferToBase64(data),
+  };
+  localStorage.setItem(stateKey, JSON.stringify(encoded));
+  localStorage.setItem(tokenKey, JSON.stringify(encoded));
+  localStorage.setItem(PERSIST_KEY, JSON.stringify({ mode: "local-encrypted", salt: persistence.salt }));
+}
+
+async function decryptStored(passphrase) {
+  const stored = safeJsonParse(localStorage.getItem(STORAGE_KEY), null);
+  if (!stored || !stored.iv || !stored.data) return null;
+  const salt = safeJsonParse(localStorage.getItem(PERSIST_KEY), {}).salt;
+  const key = await deriveKey(passphrase, salt);
+  const buffer = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: base64ToArrayBuffer(stored.iv) },
+    key,
+    base64ToArrayBuffer(stored.data)
+  );
+  const decoded = new TextDecoder().decode(buffer);
+  return { payload: JSON.parse(decoded), key, salt: salt || persistence.salt };
+}
+
+/**
+ * Configure persistence mode.
+ * @param {'session' | 'local-encrypted'} mode
+ * @param {{ passphrase?: string }} [options]
+ * @returns {Promise<void>}
+ */
+export async function setPersistence(mode, options = {}) {
+  if (mode === "session") {
+    persistence = { mode };
+    state.settings.persistence = mode;
+    state.settings.rememberTokens = false;
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ ...state, tokens: { spotify: null, google: null } }));
+    sessionStorage.setItem(TOKEN_KEY, JSON.stringify(state.tokens));
+    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.setItem(PERSIST_KEY, JSON.stringify({ mode }));
+    notify();
+    return;
+  }
+
+  if (mode === "local-encrypted") {
+    const passphrase = options.passphrase;
+    if (!passphrase) throw new Error("Passphrase required for encrypted persistence");
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const key = await deriveKey(passphrase, arrayBufferToBase64(salt.buffer));
+    persistence = { mode, key, salt: arrayBufferToBase64(salt.buffer) };
+    state.settings.persistence = mode;
+    state.settings.rememberTokens = true;
+    await encryptAndStore(
+      JSON.stringify({ snapshot: state, tokens: state.tokens }),
+      STORAGE_KEY,
+      TOKEN_KEY
+    );
+    notify();
+  }
+}
+
+/**
+ * Attempt to unlock encrypted storage with a passphrase.
+ * @param {string} passphrase
+ * @returns {Promise<boolean>}
+ */
+export async function unlockEncryptedState(passphrase) {
+  try {
+    const decrypted = await decryptStored(passphrase);
+    if (!decrypted) return false;
+    persistence = { mode: "local-encrypted", key: decrypted.key, salt: decrypted.salt };
+    const { snapshot, tokens } = decrypted.payload;
+    applySnapshot(snapshot);
+    state.tokens = tokens;
+    state.settings.persistence = "local-encrypted";
+    state.settings.rememberTokens = true;
+    notify();
+    return true;
+  } catch (error) {
+    console.error("unlockEncryptedState failed", error);
+    return false;
+  }
+}
+
+/**
+ * Store a resume checkpoint.
+ * @param {any} checkpoint
+ */
+export function saveResumeCheckpoint(checkpoint) {
+  sessionStorage.setItem(RESUME_KEY, JSON.stringify(checkpoint));
+  state.transfer.report = checkpoint;
+  notify();
+}
+
+/**
+ * Load checkpoint from storage.
+ * @returns {any}
+ */
+export function loadResumeCheckpoint() {
+  const checkpoint = safeJsonParse(sessionStorage.getItem(RESUME_KEY), null);
+  if (checkpoint) {
+    state.transfer.report = checkpoint;
+  }
+  return checkpoint;
+}
+
+export function clearResumeCheckpoint() {
+  sessionStorage.removeItem(RESUME_KEY);
+  state.transfer.report = null;
+  notify();
+}
+
+/**
+ * Set OAuth token for the provider.
+ * @param {'spotify' | 'google'} provider
+ * @param {import("./auth/oauth.js").TokenResponse | null} token
+ */
+export function setToken(provider, token) {
+  state.tokens[provider] = token;
+  persistState();
+  notify();
+}
+
+export function getToken(provider) {
+  return state.tokens[provider];
+}
+
+function arrayBufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  bytes.forEach((b) => (binary += String.fromCharCode(b)));
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(base64) {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+async function deriveKey(passphrase, existingSalt) {
+  const salt = existingSalt ? base64ToArrayBuffer(existingSalt) : crypto.getRandomValues(new Uint8Array(16)).buffer;
+  const baseKey = await crypto.subtle.importKey("raw", stringToBuffer(passphrase), "PBKDF2", false, ["deriveKey"]);
+  const key = await crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations: 120_000,
+      hash: "SHA-256",
+    },
+    baseKey,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"]
+  );
+  return key;
+}

--- a/src/ui/components/logPane.js
+++ b/src/ui/components/logPane.js
@@ -1,0 +1,30 @@
+/**
+ * Display log entries.
+ * @param {{ entries: { level: string, message: string, timestamp: number }[] }} props
+ * @returns {HTMLElement}
+ */
+export function LogPane(props) {
+  const container = document.createElement("section");
+  container.className = "lb-log-pane";
+  container.setAttribute("data-card", "");
+
+  const heading = document.createElement("h3");
+  heading.textContent = "Activity log";
+  container.appendChild(heading);
+
+  const list = document.createElement("ul");
+  if (!props.entries.length) {
+    const empty = document.createElement("li");
+    empty.textContent = "No log entries yet.";
+    list.appendChild(empty);
+  } else {
+    props.entries.forEach((entry) => {
+      const item = document.createElement("li");
+      const time = new Date(entry.timestamp).toLocaleTimeString();
+      item.textContent = `[${time}] ${entry.level.toUpperCase()} — ${entry.message}`;
+      list.appendChild(item);
+    });
+  }
+  container.appendChild(list);
+  return container;
+}

--- a/src/ui/components/matchReview.js
+++ b/src/ui/components/matchReview.js
@@ -1,0 +1,42 @@
+import { formatDuration } from "../../util.js";
+
+/**
+ * Match review component for manual selection.
+ * @param {{ track: any, candidates: any[], onSelect: (candidate: any) => void }} props
+ */
+export function MatchReview(props) {
+  const container = document.createElement("div");
+  container.className = "lb-match-review";
+  container.setAttribute("data-card", "");
+
+  const original = document.createElement("section");
+  original.innerHTML = `
+    <h3>Original track</h3>
+    <p><strong>${props.track.title}</strong></p>
+    <p>${props.track.artists?.join(", ") ?? ""}</p>
+    <p>${props.track.album ?? ""}</p>
+    <p>${props.track.duration_ms ? formatDuration(props.track.duration_ms) : ""}</p>
+  `;
+
+  const candidateList = document.createElement("div");
+  candidateList.className = "lb-match-candidates";
+  candidateList.setAttribute("role", "listbox");
+
+  props.candidates.forEach((candidate) => {
+    const item = document.createElement("button");
+    item.type = "button";
+    item.className = "lb-match-candidate";
+    item.setAttribute("role", "option");
+    item.innerHTML = `
+      <span><strong>${candidate.track.title}</strong></span>
+      <span>${candidate.track.artists?.join(", ") ?? ""}</span>
+      <span>${candidate.track.album ?? ""}</span>
+      <span>Score: ${candidate.score}</span>
+    `;
+    item.addEventListener("click", () => props.onSelect(candidate.track));
+    candidateList.appendChild(item);
+  });
+
+  container.append(original, candidateList);
+  return container;
+}

--- a/src/ui/components/playlistPicker.js
+++ b/src/ui/components/playlistPicker.js
@@ -1,0 +1,81 @@
+import { debounce } from "../../util.js";
+
+/**
+ * Playlist selection component.
+ * @param {{ playlists: any[], selectedIds: Set<string>, onChange: (ids: Set<string>) => void }} props
+ */
+export function PlaylistPicker(props) {
+  const container = document.createElement("div");
+  container.setAttribute("data-card", "");
+
+  const searchInput = document.createElement("input");
+  searchInput.type = "search";
+  searchInput.placeholder = "Search playlists";
+  searchInput.setAttribute("aria-label", "Search playlists");
+
+  const list = document.createElement("ul");
+  list.className = "lb-playlist-list";
+  list.setAttribute("role", "listbox");
+  list.tabIndex = 0;
+
+  const render = () => {
+    list.innerHTML = "";
+    const query = searchInput.value.toLowerCase();
+    props.playlists
+      .filter((playlist) => playlist.name.toLowerCase().includes(query))
+      .forEach((playlist) => {
+        const item = document.createElement("li");
+        item.className = "lb-playlist-item";
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.checked = props.selectedIds.has(playlist.id);
+        checkbox.id = `playlist-${playlist.id}`;
+        checkbox.addEventListener("change", () => {
+          if (checkbox.checked) props.selectedIds.add(playlist.id);
+          else props.selectedIds.delete(playlist.id);
+          props.onChange(new Set(props.selectedIds));
+        });
+
+        const label = document.createElement("label");
+        label.htmlFor = checkbox.id;
+        label.innerHTML = `<strong>${playlist.name}</strong><br/><small>${playlist.trackCount ?? 0} tracks</small>`;
+
+        item.append(checkbox, label);
+        list.appendChild(item);
+      });
+  };
+
+  searchInput.addEventListener(
+    "input",
+    debounce(() => {
+      render();
+    }, 200)
+  );
+
+  const actions = document.createElement("div");
+  actions.className = "lb-button-row";
+
+  const selectAll = document.createElement("button");
+  selectAll.type = "button";
+  selectAll.textContent = "Select all";
+  selectAll.addEventListener("click", () => {
+    props.playlists.forEach((playlist) => props.selectedIds.add(playlist.id));
+    props.onChange(new Set(props.selectedIds));
+    render();
+  });
+
+  const clearBtn = document.createElement("button");
+  clearBtn.type = "button";
+  clearBtn.className = "lb-button-secondary";
+  clearBtn.textContent = "Clear";
+  clearBtn.addEventListener("click", () => {
+    props.selectedIds.clear();
+    props.onChange(new Set());
+    render();
+  });
+
+  actions.append(selectAll, clearBtn);
+  container.append(searchInput, list, actions);
+  render();
+  return container;
+}

--- a/src/ui/components/progressBar.js
+++ b/src/ui/components/progressBar.js
@@ -1,0 +1,34 @@
+/**
+ * Render progress bar component.
+ * @param {{ label: string }} props
+ * @returns {{ element: HTMLElement, setProgress: (value: number, max: number) => void }}
+ */
+export function ProgressBar(props) {
+  const wrapper = document.createElement("div");
+  wrapper.setAttribute("data-card", "");
+
+  const label = document.createElement("div");
+  label.textContent = props.label;
+  label.className = "lb-progress-label";
+
+  const progress = document.createElement("div");
+  progress.className = "lb-progress";
+  progress.setAttribute("role", "progressbar");
+  progress.setAttribute("aria-valuemin", "0");
+
+  const bar = document.createElement("div");
+  bar.className = "lb-progress-bar";
+  progress.appendChild(bar);
+
+  wrapper.append(label, progress);
+
+  return {
+    element: wrapper,
+    setProgress(value, max) {
+      const ratio = max > 0 ? Math.min(1, value / max) : 0;
+      bar.style.width = `${Math.round(ratio * 100)}%`;
+      bar.setAttribute("aria-valuenow", String(value));
+      bar.setAttribute("aria-valuemax", String(max));
+    },
+  };
+}

--- a/src/ui/components/providerConnectCard.js
+++ b/src/ui/components/providerConnectCard.js
@@ -1,0 +1,72 @@
+import { translate } from "../i18n.js";
+
+/**
+ * Render provider connect card.
+ * @param {{ provider: 'spotify' | 'google', locale: string, icon: string, token: any, canConnect?: boolean, disabledMessage?: string, onConnect: () => void, onDisconnect: () => void }} props
+ * @returns {HTMLElement}
+ */
+export function ProviderConnectCard(props) {
+  const card = document.createElement("div");
+  card.setAttribute("data-card", "");
+  card.className = "lb-provider-card";
+  const canConnect = props.canConnect ?? true;
+  const disabledReason = !canConnect ? props.disabledMessage : null;
+
+  const header = document.createElement("header");
+  header.className = "lb-card-header";
+
+  const title = document.createElement("h2");
+  title.className = "lb-card-title";
+  title.textContent = props.provider === "spotify" ? "Spotify" : "YouTube";
+
+  const status = document.createElement("span");
+  status.className = "lb-pill";
+  status.textContent = props.token ? "Connected" : "Disconnected";
+  status.setAttribute("role", "status");
+
+  header.append(title, status);
+
+  const description = document.createElement("p");
+  description.className = "lb-card-subtitle";
+  description.textContent =
+    props.provider === "spotify"
+      ? "Authorize ListBridge to read and create Spotify playlists via the official API."
+      : "Authorize ListBridge to manage YouTube playlists using OAuth 2.1.";
+
+  const buttonGroup = document.createElement("div");
+  buttonGroup.className = "lb-button-row";
+
+  const connectBtn = document.createElement("button");
+  connectBtn.type = "button";
+  connectBtn.textContent =
+    props.provider === "spotify"
+      ? translate("connect_spotify", props.locale)
+      : translate("connect_google", props.locale);
+  connectBtn.addEventListener("click", () => {
+    if (connectBtn.disabled) return;
+    props.onConnect();
+  });
+  connectBtn.disabled = Boolean(props.token) || !canConnect;
+  connectBtn.setAttribute("aria-disabled", String(connectBtn.disabled));
+  if (disabledReason) {
+    connectBtn.title = disabledReason;
+  }
+
+  const disconnectBtn = document.createElement("button");
+  disconnectBtn.type = "button";
+  disconnectBtn.className = "lb-button-secondary";
+  disconnectBtn.textContent = translate("disconnect", props.locale);
+  disconnectBtn.disabled = !props.token;
+  disconnectBtn.addEventListener("click", () => props.onDisconnect());
+
+  buttonGroup.append(connectBtn, disconnectBtn);
+  card.append(header, description);
+  if (disabledReason) {
+    const hint = document.createElement("p");
+    hint.className = "lb-card-hint";
+    hint.textContent = disabledReason;
+    card.appendChild(hint);
+  }
+  card.append(buttonGroup);
+  return card;
+}

--- a/src/ui/components/quotaHint.js
+++ b/src/ui/components/quotaHint.js
@@ -1,0 +1,12 @@
+/**
+ * Render YouTube quota usage hints.
+ * @param {{ usage: { used: number, remaining: number, daily: number } }} props
+ * @returns {HTMLElement}
+ */
+export function QuotaHint(props) {
+  const container = document.createElement("div");
+  container.className = "lb-alert lb-alert-warning";
+  container.setAttribute("role", "note");
+  container.innerHTML = `YouTube quota used: <strong>${props.usage.used}</strong> / ${props.usage.daily}. Remaining today: ${props.usage.remaining}.`;
+  return container;
+}

--- a/src/ui/components/trackTable.js
+++ b/src/ui/components/trackTable.js
@@ -1,0 +1,66 @@
+import { formatDuration } from "../../util.js";
+
+const ROW_HEIGHT = 44;
+
+/**
+ * Virtualized track table.
+ * @param {{ tracks: any[] }} props
+ */
+export function TrackTable(props) {
+  const container = document.createElement("div");
+  container.className = "lb-table-container";
+  container.setAttribute("data-card", "");
+
+  const viewport = document.createElement("div");
+  viewport.className = "lb-table-virtual";
+
+  const table = document.createElement("table");
+  table.innerHTML = `
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Title</th>
+        <th scope="col">Artists</th>
+        <th scope="col">Album</th>
+        <th scope="col">Duration</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  `;
+
+  const spacer = document.createElement("div");
+  spacer.style.height = `${props.tracks.length * ROW_HEIGHT}px`;
+  spacer.style.position = "relative";
+
+  const tbody = table.querySelector("tbody");
+
+  viewport.addEventListener("scroll", () => render());
+
+  function render() {
+    const scrollTop = viewport.scrollTop;
+    const startIndex = Math.floor(scrollTop / ROW_HEIGHT);
+    const visibleCount = Math.ceil(viewport.clientHeight / ROW_HEIGHT) + 4;
+    const endIndex = Math.min(props.tracks.length, startIndex + visibleCount);
+    const offsetY = startIndex * ROW_HEIGHT;
+    tbody.style.transform = `translateY(${offsetY}px)`;
+    tbody.innerHTML = "";
+    for (let index = startIndex; index < endIndex; index += 1) {
+      const track = props.tracks[index];
+      const row = document.createElement("tr");
+      row.innerHTML = `
+        <td>${index + 1}</td>
+        <td>${track.title}</td>
+        <td>${track.artists?.join(", ") ?? ""}</td>
+        <td>${track.album ?? ""}</td>
+        <td>${track.duration_ms ? formatDuration(track.duration_ms) : ""}</td>
+      `;
+      tbody.appendChild(row);
+    }
+  }
+
+  spacer.appendChild(table);
+  viewport.appendChild(spacer);
+  container.appendChild(viewport);
+  requestAnimationFrame(render);
+  return container;
+}

--- a/src/ui/i18n.js
+++ b/src/ui/i18n.js
@@ -1,0 +1,44 @@
+export const translations = {
+  en: {
+    welcome_title: "ListBridge",
+    welcome_subtitle: "Transfer playlists between Spotify and YouTube securely in your browser.",
+    connect_title: "Connect your providers",
+    select_title: "Select playlists",
+    map_title: "Review matches",
+    transfer_title: "Transfer playlists",
+    report_title: "Transfer report",
+    connect_spotify: "Connect Spotify",
+    connect_google: "Connect Google",
+    disconnect: "Disconnect",
+    connect_client_id_hint: "Add a Client ID to oauth.config.js to enable sign-in.",
+    export_json: "Export JSON",
+    export_csv: "Export CSV",
+    import_json: "Import JSON",
+    import_csv: "Import CSV",
+    resume_banner: "You have an unfinished transfer. Resume?",
+  },
+  ko: {
+    welcome_title: "ListBridge",
+    welcome_subtitle: "브라우저만으로 Spotify와 YouTube 간 재생목록을 안전하게 옮기세요.",
+    connect_title: "연결",
+    select_title: "재생목록 선택",
+    map_title: "매칭 검토",
+    transfer_title: "전송",
+    report_title: "보고서",
+    connect_spotify: "Spotify 연결",
+    connect_google: "Google 연결",
+    disconnect: "연결 해제",
+    connect_client_id_hint: "oauth.config.js 파일에 클라이언트 ID를 입력하면 로그인 버튼이 활성화됩니다.",
+    export_json: "JSON 내보내기",
+    export_csv: "CSV 내보내기",
+    import_json: "JSON 가져오기",
+    import_csv: "CSV 가져오기",
+    resume_banner: "미완료 전송이 있습니다. 이어서 진행하시겠습니까?",
+  },
+};
+
+export const locales = Object.keys(translations);
+
+export function translate(key, locale = "en") {
+  return translations[locale]?.[key] ?? translations.en[key] ?? key;
+}

--- a/src/ui/router.js
+++ b/src/ui/router.js
@@ -1,0 +1,40 @@
+const routes = new Map();
+let mountNode;
+let currentPath = "/";
+
+export function initRouter(node) {
+  mountNode = node;
+  window.addEventListener("hashchange", () => handleRoute(location.hash));
+  handleRoute(location.hash || "#/");
+}
+
+export function registerRoute(path, render) {
+  routes.set(path, render);
+}
+
+function handleRoute(hash) {
+  const [path, search] = hash.split("?");
+  const render = routes.get(path.replace(/^#/, "")) || routes.get("/");
+  if (!render) return;
+  const params = new URLSearchParams(search);
+  const element = render({ params, path: path.replace(/^#/, "") });
+  if (mountNode) {
+    mountNode.innerHTML = "";
+    if (element instanceof Node) {
+      mountNode.appendChild(element);
+      mountNode.focus();
+    }
+  }
+  updateNav(path);
+  currentPath = path.replace(/^#/, "");
+}
+
+function updateNav(path) {
+  document.querySelectorAll("[data-route]").forEach((link) => {
+    link.setAttribute("aria-current", link.getAttribute("href") === path ? "page" : "false");
+  });
+}
+
+export function rerender() {
+  handleRoute(`#${currentPath}`);
+}

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,422 @@
+/**
+ * Utility helpers shared across the ListBridge application.
+ * @module util
+ */
+
+const encoder = new TextEncoder();
+
+/**
+ * Sleep helper returning a promise that resolves after the provided milliseconds.
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Generate a random identifier suitable for DOM keys.
+ * @returns {string}
+ */
+export function uid() {
+  return crypto.randomUUID ? crypto.randomUUID() : `lb-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Deep merge two objects while keeping reference safety.
+ * @param {object} target
+ * @param {object} source
+ * @returns {object}
+ */
+export function deepMerge(target, source) {
+  const output = { ...target };
+  for (const [key, value] of Object.entries(source)) {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      output[key] = deepMerge(target[key] ?? {}, value);
+    } else {
+      output[key] = value;
+    }
+  }
+  return output;
+}
+
+/**
+ * Deep equality check using JSON stringification with stable keys.
+ * @param {unknown} a
+ * @param {unknown} b
+ * @returns {boolean}
+ */
+export function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object" || a === null || b === null) return false;
+  const aKeys = Object.keys(a).sort();
+  const bKeys = Object.keys(b).sort();
+  if (aKeys.length !== bKeys.length) return false;
+  for (let i = 0; i < aKeys.length; i += 1) {
+    const key = aKeys[i];
+    if (key !== bKeys[i]) return false;
+    if (!deepEqual(a[key], b[key])) return false;
+  }
+  return true;
+}
+
+/**
+ * Debounce execution of a function.
+ * @template {(...args: any[]) => void} T
+ * @param {T} fn
+ * @param {number} delay
+ * @returns {T}
+ */
+export function debounce(fn, delay = 200) {
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let timer;
+  return /** @type {T} */ (
+    function debounced(...args) {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => fn.apply(this, args), delay);
+    }
+  );
+}
+
+/**
+ * Lightweight throttle implementation.
+ * @template {(...args: any[]) => void} T
+ * @param {T} fn
+ * @param {number} delay
+ * @returns {T}
+ */
+export function throttle(fn, delay = 100) {
+  /** @type {number} */
+  let lastCall = 0;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let trailing;
+  return /** @type {T} */ (
+    function throttled(...args) {
+      const now = Date.now();
+      if (now - lastCall >= delay) {
+        lastCall = now;
+        fn.apply(this, args);
+      } else {
+        if (trailing) clearTimeout(trailing);
+        trailing = setTimeout(() => {
+          lastCall = Date.now();
+          fn.apply(this, args);
+        }, delay - (now - lastCall));
+      }
+    }
+  );
+}
+
+/**
+ * Minimal event emitter used to coordinate UI components.
+ * @returns {{on: (event: string, listener: Function) => () => void, emit: (event: string, payload?: any) => void}}
+ */
+export function createEventBus() {
+  /** @type {Map<string, Set<Function>>} */
+  const listeners = new Map();
+  return {
+    on(event, listener) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)?.add(listener);
+      return () => listeners.get(event)?.delete(listener);
+    },
+    emit(event, payload) {
+      listeners.get(event)?.forEach((listener) => listener(payload));
+    },
+  };
+}
+
+/**
+ * Exponential backoff helper with jitter.
+ * @param {(attempt: number) => Promise<any>} task
+ * @param {{ maxAttempts?: number, baseDelay?: number, maxDelay?: number, onRetry?: (error: Error, attempt: number, delay: number) => void }} options
+ * @returns {Promise<any>}
+ */
+export async function withBackoff(task, options = {}) {
+  const {
+    maxAttempts = 5,
+    baseDelay = 1500,
+    maxDelay = 60000,
+    onRetry = () => {},
+  } = options;
+  let attempt = 0;
+  while (true) {
+    try {
+      return await task(attempt);
+    } catch (error) {
+      attempt += 1;
+      if (attempt >= maxAttempts) throw error;
+      const jitter = Math.random() * 300;
+      const delay = Math.min(maxDelay, baseDelay * 2 ** (attempt - 1)) + jitter;
+      onRetry(/** @type {Error} */ (error), attempt, delay);
+      await sleep(delay);
+    }
+  }
+}
+
+/**
+ * Wrapper around fetch adding retry, cancellation and logging hooks.
+ * @param {string} url
+ * @param {RequestInit & { retry?: number, retryOn?: number[], signal?: AbortSignal }} options
+ * @returns {Promise<Response>}
+ */
+export async function fetchWithRetry(url, options = {}) {
+  const { retry = 3, retryOn = [429, 500, 502, 503, 504], signal, ...rest } = options;
+  let attempts = 0;
+  const controller = new AbortController();
+  const combinedSignal = mergeSignals(signal, controller.signal);
+
+  while (attempts <= retry) {
+    attempts += 1;
+    try {
+      const response = await fetch(url, { ...rest, signal: combinedSignal });
+      if (!response.ok && retryOn.includes(response.status) && attempts <= retry) {
+        const wait = Math.min(60000, 1500 * 2 ** (attempts - 1));
+        await sleep(wait + Math.random() * 400);
+        continue;
+      }
+      return response;
+    } catch (error) {
+      if (error.name === "AbortError") throw error;
+      if (attempts > retry) throw error;
+      await sleep(Math.min(60000, 1500 * 2 ** (attempts - 1)) + Math.random() * 400);
+    }
+  }
+  throw new Error("fetchWithRetry: exhausted attempts");
+}
+
+/**
+ * Merge AbortSignals into a single signal.
+ * @param {AbortSignal | undefined} signalA
+ * @param {AbortSignal | undefined} signalB
+ * @returns {AbortSignal | undefined}
+ */
+export function mergeSignals(signalA, signalB) {
+  if (!signalA) return signalB;
+  if (!signalB) return signalA;
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  signalA.addEventListener("abort", abort);
+  signalB.addEventListener("abort", abort);
+  return controller.signal;
+}
+
+/**
+ * In-memory least-recently-used cache.
+ */
+export class LRUCache {
+  /**
+   * @param {number} maxEntries
+   */
+  constructor(maxEntries = 100) {
+    this.max = maxEntries;
+    /** @type {Map<string, any>} */
+    this.map = new Map();
+  }
+
+  /**
+   * @param {string} key
+   * @param {any} value
+   */
+  set(key, value) {
+    if (this.map.has(key)) this.map.delete(key);
+    this.map.set(key, value);
+    if (this.map.size > this.max) {
+      const first = this.map.keys().next().value;
+      this.map.delete(first);
+    }
+  }
+
+  /**
+   * @param {string} key
+   * @returns {any}
+   */
+  get(key) {
+    if (!this.map.has(key)) return undefined;
+    const value = this.map.get(key);
+    this.map.delete(key);
+    this.map.set(key, value);
+    return value;
+  }
+
+  clear() {
+    this.map.clear();
+  }
+}
+
+/**
+ * Format milliseconds into mm:ss string.
+ * @param {number} ms
+ * @returns {string}
+ */
+export function formatDuration(ms) {
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Trigger a file download in-browser.
+ * @param {BlobPart[]} parts
+ * @param {string} filename
+ * @param {string} mime
+ */
+export function downloadFile(parts, filename, mime = "text/plain") {
+  const blob = new Blob(parts, { type: mime });
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(link.href);
+}
+
+/**
+ * Parse CSV text into objects.
+ * @param {string} text
+ * @returns {Record<string, string>[]}
+ */
+export function parseCSV(text) {
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length === 0) return [];
+  const headers = splitCsvLine(lines[0]);
+  return lines.slice(1).map((line) => {
+    const values = splitCsvLine(line);
+    /** @type {Record<string, string>} */
+    const row = {};
+    headers.forEach((header, idx) => {
+      row[header] = values[idx] ?? "";
+    });
+    return row;
+  });
+}
+
+/**
+ * Serialize array of objects into CSV text.
+ * @param {Record<string, any>[]} rows
+ * @returns {string}
+ */
+export function toCSV(rows) {
+  if (!rows.length) return "";
+  const headers = Object.keys(rows[0]);
+  const headerLine = headers.join(",");
+  const body = rows
+    .map((row) => headers.map((key) => formatCSVValue(row[key])).join(","))
+    .join("\n");
+  return `${headerLine}\n${body}`;
+}
+
+function formatCSVValue(value) {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  if (str.includes(",") || str.includes("\n") || str.includes('"')) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
+}
+
+function splitCsvLine(line) {
+  const result = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === "," && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result.map((value) => value.trim());
+}
+
+/**
+ * Download JSON data as a file.
+ * @param {any} data
+ * @param {string} filename
+ */
+export function downloadJSON(data, filename) {
+  downloadFile([JSON.stringify(data, null, 2)], filename, "application/json");
+}
+
+/**
+ * Convert string to ArrayBuffer.
+ * @param {string} value
+ * @returns {ArrayBuffer}
+ */
+export function stringToBuffer(value) {
+  return encoder.encode(value).buffer;
+}
+
+/**
+ * Safe JSON parse returning fallback on error.
+ * @template T
+ * @param {string | null} text
+ * @param {T} fallback
+ * @returns {T}
+ */
+export function safeJsonParse(text, fallback) {
+  try {
+    return text ? JSON.parse(text) : fallback;
+  } catch (error) {
+    console.warn("safeJsonParse: failed", error);
+    return fallback;
+  }
+}
+
+/**
+ * Broadcast text to screen reader live region.
+ * @param {string} message
+ */
+export function announce(message) {
+  let region = document.querySelector("[data-sr-region]");
+  if (!region) {
+    const template = document.getElementById("sr-live-region");
+    if (template instanceof HTMLTemplateElement) {
+      region = template.content.firstElementChild?.cloneNode(true);
+      if (region) {
+        region.setAttribute("data-sr-region", "");
+        document.body.appendChild(region);
+      }
+    }
+  }
+  if (region) {
+    region.textContent = message;
+  }
+}
+
+/**
+ * Create a cancellable token.
+ * @returns {{ signal: AbortSignal, cancel: () => void }}
+ */
+export function createAbortable() {
+  const controller = new AbortController();
+  return {
+    signal: controller.signal,
+    cancel: () => controller.abort(),
+  };
+}
+
+/**
+ * Get localized string from dictionary.
+ * @param {Record<string, Record<string, string>>} dict
+ * @param {string} key
+ * @param {string} locale
+ * @returns {string}
+ */
+export function t(dict, key, locale) {
+  const entry = dict[locale] ?? dict.en;
+  return entry[key] ?? key;
+}

--- a/src/workflow/export.js
+++ b/src/workflow/export.js
@@ -1,0 +1,45 @@
+import { toCSV, downloadFile, downloadJSON } from "../util.js";
+
+/**
+ * Export playlist collection to JSON file.
+ * @param {any} data
+ * @param {string} [filename]
+ */
+export function exportAsJSON(data, filename = "playlists.json") {
+  downloadJSON(data, filename);
+}
+
+/**
+ * Export playlists to CSV pair (playlists.csv + tracks.csv).
+ * @param {{ playlists: any[] }} collection
+ */
+export function exportAsCSV(collection) {
+  const playlistsRows = collection.playlists.map((playlist) => ({
+    playlist_name: playlist.name,
+    description: playlist.description ?? "",
+    visibility: playlist.visibility ?? "private",
+    source_name: collection.source ?? "unknown",
+  }));
+  const tracksRows = [];
+  collection.playlists.forEach((playlist) => {
+    playlist.tracks?.forEach((track, index) => {
+      tracksRows.push({
+        playlist_name: playlist.name,
+        position: index + 1,
+        title: track.title,
+        artists: track.artists?.join("; ") ?? "",
+        album: track.album ?? "",
+        duration_ms: track.duration_ms ?? "",
+        isrc: track.isrc ?? "",
+        release_year: track.release_year ?? "",
+        explicit: track.explicit ?? false,
+        cover_url: track.coverUrl ?? "",
+      });
+    });
+  });
+
+  const playlistsCsv = toCSV(playlistsRows);
+  const tracksCsv = toCSV(tracksRows);
+  downloadFile([playlistsCsv], "playlists.csv", "text/csv");
+  downloadFile([tracksCsv], "tracks.csv", "text/csv");
+}

--- a/src/workflow/import.js
+++ b/src/workflow/import.js
@@ -1,0 +1,52 @@
+import { parseCSV, safeJsonParse } from "../util.js";
+
+/**
+ * Parse playlists JSON file.
+ * @param {File} file
+ * @returns {Promise<any>}
+ */
+export async function importFromJSON(file) {
+  const text = await file.text();
+  return safeJsonParse(text, {});
+}
+
+/**
+ * Parse CSV playlist + tracks files into structured data.
+ * @param {{ playlists: File, tracks: File }} files
+ */
+export async function importFromCSV(files) {
+  const [playlistsText, tracksText] = await Promise.all([files.playlists.text(), files.tracks.text()]);
+  const playlistRows = parseCSV(playlistsText);
+  const trackRows = parseCSV(tracksText);
+
+  const playlists = playlistRows.map((row) => ({
+    id: row.playlist_name,
+    name: row.playlist_name,
+    description: row.description,
+    visibility: row.visibility,
+    source: row.source_name,
+    tracks: [],
+  }));
+  const playlistMap = new Map(playlists.map((playlist) => [playlist.name, playlist]));
+
+  trackRows.forEach((row) => {
+    const target = playlistMap.get(row.playlist_name);
+    if (!target) return;
+    target.tracks.push({
+      title: row.title,
+      artists: row.artists ? row.artists.split(/;\s*/) : [],
+      album: row.album,
+      duration_ms: Number(row.duration_ms) || undefined,
+      isrc: row.isrc || undefined,
+      release_year: Number(row.release_year) || undefined,
+      explicit: row.explicit === "true",
+      coverUrl: row.cover_url,
+    });
+  });
+
+  return {
+    source: "csv",
+    playlists,
+    importedAt: Date.now(),
+  };
+}

--- a/src/workflow/resume.js
+++ b/src/workflow/resume.js
@@ -1,0 +1,24 @@
+import { saveResumeCheckpoint, loadResumeCheckpoint, clearResumeCheckpoint } from "../state.js";
+
+/**
+ * Persist transfer progress so that the user can resume later.
+ * @param {any} checkpoint
+ */
+export function saveCheckpoint(checkpoint) {
+  saveResumeCheckpoint({
+    ...checkpoint,
+    savedAt: Date.now(),
+  });
+}
+
+export function getCheckpoint() {
+  return loadResumeCheckpoint();
+}
+
+export function clearCheckpoint() {
+  clearResumeCheckpoint();
+}
+
+export function hasCheckpoint() {
+  return Boolean(loadResumeCheckpoint());
+}

--- a/src/workflow/transfer.js
+++ b/src/workflow/transfer.js
@@ -1,0 +1,118 @@
+import { updateState, getState } from "../state.js";
+import { findCandidates } from "../mapping/searcher.js";
+import { announce } from "../util.js";
+import { saveCheckpoint, clearCheckpoint } from "./resume.js";
+
+/**
+ * Transfer playlists to the target provider.
+ * @param {{ collection: any, target: { providerName: string, createPlaylist: Function, addItems: Function, search: Function } }} options
+ */
+export async function transferCollection(options) {
+  const { collection, target } = options;
+  const state = getState();
+  const matches = { ...state.mapping.matches };
+  const totalTracks = collection.playlists.reduce((acc, playlist) => acc + (playlist.tracks?.length ?? 0), 0);
+  const failures = [];
+  let processed = 0;
+
+  updateState({
+    transfer: {
+      ...state.transfer,
+      status: "running",
+      total: totalTracks,
+      processed: 0,
+      failures: [],
+    },
+  });
+
+  for (const playlist of collection.playlists) {
+    const targetPlaylist = await target.createPlaylist({
+      name: `${playlist.name} · via ListBridge`,
+      description: buildDescription(collection.source, playlist.description),
+      visibility: playlist.visibility ?? "private",
+    });
+    updateState({
+      mapping: {
+        ...getState().mapping,
+        logs: [
+          ...getState().mapping.logs,
+          { level: "info", message: `Created playlist ${targetPlaylist.id}`, timestamp: Date.now() },
+        ],
+      },
+    });
+    const mappedIds = [];
+
+    for (const track of playlist.tracks ?? []) {
+      processed += 1;
+      const trackKey = getTrackKey(track);
+      let selection = matches[trackKey];
+      if (!selection) {
+        const candidates = await findCandidates(track, {
+          providerName: target.providerName,
+          search: target.search,
+          locale: state.locale,
+        });
+        if (candidates.best) {
+          selection = candidates.best.track;
+          matches[trackKey] = selection;
+        } else {
+          failures.push({ track, reason: "No confident match", candidates: candidates.candidates });
+          updateState({
+            mapping: {
+              ...getState().mapping,
+              logs: [
+                ...getState().mapping.logs,
+                { level: "warn", message: `No confident match for ${track.title}`, timestamp: Date.now() },
+              ],
+            },
+          });
+          continue;
+        }
+      }
+      mappedIds.push(selection.sourceIds?.[target.providerName] ?? selection.id);
+      updateState({
+        transfer: {
+          ...getState().transfer,
+          processed,
+        },
+      });
+    }
+
+    if (mappedIds.length) {
+      await target.addItems(targetPlaylist.id, mappedIds);
+    }
+
+    saveCheckpoint({
+      playlistId: playlist.id,
+      targetPlaylistId: targetPlaylist.id,
+      processed,
+      total: totalTracks,
+      failures,
+    });
+  }
+
+  updateState({
+    mapping: { ...getState().mapping, matches },
+    transfer: {
+      status: "completed",
+      total: totalTracks,
+      processed,
+      failures,
+      report: {
+        completedAt: Date.now(),
+        failures,
+      },
+    },
+  });
+  clearCheckpoint();
+  announce("재생목록 전송이 완료되었습니다.");
+}
+
+function buildDescription(sourceName, existingDescription = "") {
+  const date = new Date().toISOString();
+  return `${existingDescription}\n\nImported from ${sourceName ?? "unknown"} via ListBridge on ${date}`.trim();
+}
+
+function getTrackKey(track) {
+  return track.sourceIds?.spotify ?? track.sourceIds?.youtube ?? track.id;
+}

--- a/test/e2e.md
+++ b/test/e2e.md
@@ -1,0 +1,35 @@
+# ListBridge Manual Test Scenarios
+
+These end-to-end flows can be performed entirely in a local browser without server code.
+
+1. **First run setup**
+   - Serve the repository root using `npm run dev` or `python3 -m http.server`.
+   - Visit `http://localhost:4173` (or the port you chose).
+   - Confirm the welcome page renders with dark/light toggle.
+
+2. **OAuth configuration**
+   - Open `/docs/OAUTH_SETUP_SPOTIFY.md` and `/docs/OAUTH_SETUP_GOOGLE.md` to create client IDs.
+   - Edit `oauth.config.js`, replace the Spotify/Google client IDs, and reload the app.
+   - On **Connect**, confirm both providers show “Configured” and the buttons are enabled. Click each to complete the PKCE flow.
+
+3. **Playlist import/export**
+   - On **Select**, click *Load Spotify playlists*. A list of playlists should appear.
+   - Select a playlist and ensure the preview table shows tracks.
+   - Click **Export JSON/CSV** and verify files download.
+   - Use the buttons to import `data/sample-playlists.json` and `data/sample-playlists.csv` + `data/sample-tracks.csv`.
+
+4. **Auto matching**
+   - Navigate to **Match** and run *Auto matching*.
+   - For tracks below the confidence threshold, review manual suggestions and select the best candidate.
+
+5. **Transfer & Resume**
+   - Go to **Transfer** and start the transfer. Observe the progress bar and quota hint.
+   - During transfer, refresh the page to verify the resume banner appears. Resume the operation.
+
+6. **Report**
+   - After completion, open **Report** to view logs and failure counts.
+   - Download the failure CSV (if available) from the log section for troubleshooting.
+
+7. **PWA smoke test**
+   - Open Chrome DevTools → Lighthouse. Run audits without PWA; expect 90+ scores per specification.
+

--- a/test/mapping.test.js
+++ b/test/mapping.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { normalizeText, normalizeArtists } from "../src/mapping/normalizer.js";
+import { scoreMatch } from "../src/mapping/scorer.js";
+
+function run() {
+  assert.equal(normalizeText("Song Title (Remastered 2011)"), "song title");
+  assert.equal(normalizeText("라이브 버전" , "ko"), "");
+
+  const artists = normalizeArtists(["Dreamstatic feat. Feather", "Analog Horizon"]);
+  assert.deepEqual(artists, ["dreamstatic", "feather", "analog horizon"]);
+
+  const source = {
+    title: "City Lights",
+    artists: ["Dreamstatic", "Feather"],
+    duration_ms: 198000,
+    release_year: 2020,
+    explicit: false,
+  };
+  const candidate = {
+    title: "City Lights (Official Video)",
+    artists: ["Dreamstatic", "Feather"],
+    duration_ms: 199000,
+    release_year: 2020,
+    explicit: false,
+  };
+  const { score } = scoreMatch(source, candidate);
+  assert(score >= 75, "Expected confident match score");
+
+  console.log("All mapping tests passed");
+}
+
+run();

--- a/test/providers.mock.js
+++ b/test/providers.mock.js
@@ -1,0 +1,36 @@
+export const spotifyMock = {
+  listPlaylists: async () => [
+    { id: "mock-1", name: "Mock Playlist", description: "Example", trackCount: 2 },
+  ],
+  readTracks: async () => [
+    {
+      id: "mock-track-1",
+      title: "City Lights",
+      artists: ["Dreamstatic", "Feather"],
+      album: "Skyline",
+      duration_ms: 198000,
+      release_year: 2020,
+      explicit: false,
+      sourceIds: { spotify: "mock:1" },
+    },
+  ],
+  search: async (query) => [{
+    id: "mock-track-1",
+    title: query,
+    artists: ["Mock Artist"],
+    duration_ms: 200000,
+    sourceIds: { spotify: "mock:1" },
+  }],
+};
+
+export const youtubeMock = {
+  search: async (query) => [{
+    id: "yt-1",
+    title: query,
+    artists: ["Mock Channel"],
+    duration_ms: 198000,
+    sourceIds: { youtube: "yt:1" },
+  }],
+  createPlaylist: async ({ name }) => ({ id: `created-${name}` }),
+  addItems: async () => {},
+};


### PR DESCRIPTION
## Summary
- add static callback redirect pages for Spotify and Google so PKCE redirects land back in the SPA on static hosts
- copy the callback helpers in the build output and update the deployment and OAuth docs to reference them

## Testing
- npm run lint -- --fix
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0e2576d8483299f8813ac6cbfbaaf